### PR TITLE
Listen only and full audio spec codec and fixes

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -117,3 +117,10 @@ conference-media-specs:
     as_main: "300"
     tias_content: "1500000"
     as_content: "1500"
+  OPUS:
+    useinbandfec: "0"
+    maxaveragebitrate: "30000"
+    maxplaybackrate: "48000"
+    ptime: "20"
+    minptime: "10"
+    maxptime: "40"

--- a/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
+++ b/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
@@ -80,7 +80,7 @@ module.exports = class Freeswitch extends EventEmitter {
     const userAgent = this._userAgents[sourceId];
     const { voiceBridge } = userAgent;
     const source = this._sessions[voiceBridge];
-    const rtpConverter = this._rtpConverters[voiceBridge].elementId;
+    const rtpConverter = this._rtpConverters[sourceId].elementId;
 
     Logger.debug("[mcs-media-freeswitch] Connecting", rtpConverter, "to", sinkId);
 
@@ -111,7 +111,7 @@ module.exports = class Freeswitch extends EventEmitter {
         Logger.info("[mcs-media-freeswitch] Releasing endpoint", elementId, "from room", roomId);
 
         await this._stopUserAgent(elementId);
-        await this._stopRtpConverter(roomId);
+        await this._stopRtpConverter(roomId, elementId);
         return resolve();
       }
       catch (error) {
@@ -138,14 +138,14 @@ module.exports = class Freeswitch extends EventEmitter {
     });
   }
 
-  async _stopRtpConverter (roomId) {
+  async _stopRtpConverter (voiceBridge, elementId) {
     return new Promise(async (resolve, reject) => {
-      let rtpConverter = this._rtpConverters[roomId];
+      let rtpConverter = this._rtpConverters[elementId];
       if (rtpConverter) {
         Logger.debug("[mcs-media-freeswitch] Stopping converter", rtpConverter.elementId);
-        await this._Kurento.stop(roomId, C.MEDIA_TYPE.RTP, rtpConverter.elementId);
+        await this._Kurento.stop(voiceBridge, C.MEDIA_TYPE.RTP, rtpConverter.elementId);
         this.balancer.decrementHostStreams(rtpConverter.host.id, 'audio');
-        delete this._rtpConverters[roomId];
+        delete this._rtpConverters[elementId];
         return resolve();
       }
       else {
@@ -164,12 +164,12 @@ module.exports = class Freeswitch extends EventEmitter {
         if (userAgent) {
 
           if (sdpOffer == null) {
-            if (this._rtpConverters[voiceBridge]) {
-              mediaElement = this._rtpConverters[voiceBridge].elementId;
+            if (this._rtpConverters[elementId]) {
+              mediaElement = this._rtpConverters[elementId].elementId;
             }
             else {
               ({ mediaElement, host }  = await this._Kurento.createMediaElement(voiceBridge, 'RtpEndpoint'));
-              this._rtpConverters[voiceBridge] = { elementId: mediaElement, host };
+              this._rtpConverters[elementId] = { elementId: mediaElement, host };
               this.balancer.incrementHostStreams(host.id, 'audio');
             }
             Logger.info("[mcs-media-freeswitch] RTP endpoint equivalent to SIP instance is", mediaElement, "indexed at", voiceBridge);

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -13,6 +13,7 @@ const config = require('config');
 const Logger = require('../utils/logger');
 const AdapterFactory = require('../adapters/adapter-factory');
 const { handleError } = require('../utils/util');
+const MEDIA_SPECS = config.get('conference-media-specs');
 
 const LOG_PREFIX = "[mcs-media-session]";
 
@@ -49,9 +50,7 @@ module.exports = class MediaSession {
     this._customIdentifier = options.customIdentifier? options.customIdentifier : null;
     // Media server interface based on given adapter
     this._isComposedAdapter = isComposedAdapter(this._adapter);
-
     this._adapters = AdapterFactory.getAdapters(this._adapter);
-
     // Media server adapter ID for this session's element
     this.videoMediaElement;
     this.audioMediaElement;
@@ -65,8 +64,12 @@ module.exports = class MediaSession {
       application: false,
       message: false,
     }
-    this._muted = false;
+    // Nature of the media according to the use case (main || content || audio)
     this._mediaProfile = options.mediaProfile? options.mediaProfile : 'main';
+    // Media specs for the media. If not specified, falls back to the default
+    this.mediaSpecs = options.mediaSpecs? options.mediaSpecs : MEDIA_SPECS;
+
+    this._muted = false;
   }
 
   async start () {

--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -12,8 +12,8 @@ const rid = require('readable-id');
 const config = require('config');
 const Logger = require('../utils/logger');
 const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
-const MEDIA_SPECS = config.get('conference-media-specs');
 const { handleError } = require('../utils/util');
+const MEDIA_SPECS = config.get('conference-media-specs');
 const LOG_PREFIX = '[mcs-media]';
 
 module.exports = class Media {
@@ -27,7 +27,6 @@ module.exports = class Media {
     host,
     options = {}
   ) {
-    // {SdpWrapper} SdpWrapper
     this.id = rid();
     this.roomId = roomId;
     this.userId = userId;
@@ -48,6 +47,9 @@ module.exports = class Media {
     this.outboundIceQueue = [];
     this._mediaStateSubscription = false;
     this._iceSubscription = false;
+
+    // Media specs for the media. If not specified, falls back to the default
+    this.mediaSpecs = options.mediaSpecs? options.mediaSpecs : MEDIA_SPECS;
 
     Logger.trace(LOG_PREFIX, "New", type, "media", this.getMediaInfo());
   }

--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -104,6 +104,10 @@ module.exports = class Media {
           Balancer.decrementHostStreams(this.host.id, 'video');
         }
 
+        if (this.hasAudio) {
+          Balancer.decrementHostStreams(this.host.id, 'audio');
+        }
+
         this.status = C.STATUS.STOPPED;
         Logger.info(LOG_PREFIX, "Session", this.id, "stopped with status", this.status);
         GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.mediaSessionId, mediaSessionId: this.mediaSessionId });

--- a/lib/mcs-core/lib/model/sdp-media.js
+++ b/lib/mcs-core/lib/model/sdp-media.js
@@ -12,7 +12,6 @@ const Media = require('./media');
 const Balancer = require('../media/balancer');
 const config = require('config');
 const Logger = require('../utils/logger');
-const MEDIA_SPECS = config.get('conference-media-specs');
 
 module.exports = class SDPMedia extends Media {
   constructor(
@@ -50,7 +49,7 @@ module.exports = class SDPMedia extends Media {
         this._shouldRenegotiate = true;
       }
 
-      this.offer = new SdpWrapper(offer, MEDIA_SPECS, this.mediaProfile);
+      this.offer = new SdpWrapper(offer, this.mediaSpecs, this.mediaProfile);
     }
   }
 
@@ -61,7 +60,7 @@ module.exports = class SDPMedia extends Media {
         answer = SdpWrapper.nonPureReplaceServerIpv4(answer, this.host.ip);
       }
 
-      this.answer = new SdpWrapper(answer, MEDIA_SPECS, this.mediaProfile);
+      this.answer = new SdpWrapper(answer, this.mediaSpecs, this.mediaProfile);
       this.mediaTypes.video = this.answer.hasAvailableVideoCodec();
       this.mediaTypes.audio = this.answer.hasAvailableAudioCodec();
     }

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -13,7 +13,6 @@ const SDPMedia = require('./sdp-media');
 const config = require('config');
 const Logger = require('../utils/logger');
 const AdapterFactory = require('../adapters/adapter-factory');
-const MEDIA_SPECS = config.get('conference-media-specs');
 const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
 const Balancer = require('../media/balancer');
 
@@ -42,13 +41,13 @@ module.exports = class SDPSession extends MediaSession {
         this._shouldRenegotiate = true;
       }
 
-      this._offer = new SdpWrapper(offer, MEDIA_SPECS, this._mediaProfile);
+      this._offer = new SdpWrapper(offer, this.mediaSpecs, this._mediaProfile);
     }
   }
 
   setAnswer (answer) {
     if (answer) {
-      this._answer = new SdpWrapper(answer, MEDIA_SPECS, this._mediaProfile);
+      this._answer = new SdpWrapper(answer, this.mediaSpecs, this._mediaProfile);
     }
   }
 

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -59,8 +59,12 @@ module.exports = class User {
   subscribe (sdp, type, source, params = {}) {
     return new Promise(async (resolve, reject) => {
       try {
+        // Fetch the source media specs to make the subscriber match it
+        params.mediaSpecs = source.mediaSpecs;
+
         const session = this.createMediaSession(sdp, type, params);
         const answer = await this.startSession(session.id);
+
         let connectionType;
         if (params.content) {
           connectionType = 'CONTENT';
@@ -69,6 +73,7 @@ module.exports = class User {
         if (source !== 'default') {
           await source.connect(session, connectionType);
         }
+
         resolve({ session, answer });
       }
       catch (err) {

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -46,9 +46,8 @@ module.exports = class SdpWrapper {
   }
 
   static getAudioSDP (sdp) {
-    const sdh = SdpWrapper.getSessionDescription(sdp);
     const asdp =  SdpWrapper.getAudioDescription(sdp);
-    return sdh + asdp;
+    return asdp;
   }
 
   hasAudio () {

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -253,21 +253,22 @@ module.exports = class SdpWrapper {
     }
   }
 
-  _fetchSpecCodec (spec, type) {
-    let specCodec;
+  _fetchSpecCodecs (spec, type) {
+    let videoCodec, audioCodec;
     switch (type) {
       case 'content':
-        specCodec = spec.codec_video_content;
+        videoCodec = spec.codec_video_content;
         break;
       case 'main':
       default:
-        specCodec = spec.codec_video_main;
+        videoCodec = spec.codec_video_main;
+        audioCodec = spec.codec_audio;
     }
 
-    return specCodec;
+    return { videoCodec, audioCodec };
   }
 
-  _fetchSpecProfileParams (spec, type) {
+  _fetchH264ProfileParams (spec, type) {
     let profileParams = '';
     switch (type) {
       case 'content':
@@ -299,47 +300,79 @@ module.exports = class SdpWrapper {
     }
   }
 
+  _fetchOPUSProfileParams (spec) {
+    let profileParams = '';
+
+    Object.keys(spec).forEach(p => {
+      if (profileParams !== '') {
+        profileParams += `; ${p}=${spec[p]}`;
+      } else {
+        profileParams += `${p}=${spec[p]}`;
+      }
+    });
+
+    return profileParams;
+  }
 
   submitToSpec (sdp, spec, type) {
     let res = transform.parse(sdp);
-    let specCodec = this._fetchSpecCodec(spec, type);
+    let { videoCodec, audioCodec } = this._fetchSpecCodecs(spec, type);
     let pt = 0;
     let idx = 0;
 
-    res = SdpWrapper.filterByVideoCodec(res, specCodec);
+    res = SdpWrapper.filterByVideoCodec(res, videoCodec);
 
-    if (specCodec === 'ANY') {
-      // We use the VP8 SDP specifiers if a preferred codec wasn't defined in config
-      specCodec = 'VP8';
+    if (videoCodec === 'ANY') {
+      // We use the VP8 SDP specifiers if a preferred video codec wasn't defined in config
+      videoCodec = 'VP8';
+    }
+
+    if (audioCodec === 'ANY') {
+      // We use the OPUS SDP specifiers if a preferred audio codec wasn't defined in config
+      audioCodec = 'OPUS';
     }
 
     res.media.forEach(ml => {
-      if(ml.type == 'video') {
+      if (ml.type == 'video') {
         ml.fmtp.forEach(fmtp => {
           let fmtpConfig = transform.parseParams(fmtp.config);
           let profileId = fmtpConfig['profile-level-id'];
           // Reconfiguring the FMTP to coerce endpoints to obey to our will
-          if (specCodec === 'H264') {
-            let configProfile = "profile-level-id=" + spec[specCodec].profile_level_id;
-            configProfile += this._fetchSpecProfileParams(spec[specCodec], type);
+          if (videoCodec === 'H264') {
+            let configProfile = "profile-level-id=" + spec[videoCodec].profile_level_id;
+            configProfile += this._fetchH264ProfileParams(spec[videoCodec], type);
 
-            if (spec[specCodec].packetization_mode) {
-              configProfile += `; packetization-mode=${spec[specCodec].packetization_mode}`;
+            if (spec[videoCodec].packetization_mode) {
+              configProfile += `; packetization-mode=${spec[videoCodec].packetization_mode}`;
             }
 
-            if (spec[specCodec].level_asymmetry_allowed) {
-              configProfile += `; level-asymmetry-allowed=${spec[specCodec].level_asymmetry_allowed}`;
+            if (spec[videoCodec].level_asymmetry_allowed) {
+              configProfile += `; level-asymmetry-allowed=${spec[videoCodec].level_asymmetry_allowed}`;
             }
-
 
             fmtp.config = configProfile;
           }
           idx++;
         });
       }
+
+      if (ml.type === 'audio') {
+        ml.rtp.forEach(rtp => {
+          if (rtp.codec.toUpperCase().includes('OPUS')) {
+            let fmtps = ml.fmtp.filter(f => f.payload === rtp.payload);
+            fmtps.forEach(fmtp => {
+              let fmtpConfig = transform.parseParams(fmtp.config);
+              // Reconfiguring the FMTP to coerce endpoints to obey to audio
+              let configProfile = this._fetchOPUSProfileParams(spec[audioCodec]);
+              fmtp.config = configProfile;
+              idx++;
+            });
+          }
+        });
+      }
     });
 
-    res = this.addBandwidth(res, 'video', this._fetchSpec_TI_AS(spec, specCodec, type));
+    res = this.addBandwidth(res, 'video', this._fetchSpec_TI_AS(spec, videoCodec, type));
 
     return transform.write(res);
   }


### PR DESCRIPTION
- Added OPUS specs to better match the listen only subscribers from the browser with the FreeSWITCH parameters. This should improve overall listen only audio quality. The values in `default.example.yml` should be altered to match the ones configured on FreeSWITCH. The values in this PR correspond to the ones present in BBB's 2.2/FS 1.8.2 version.
- Fixed audio stream accounting in mcs-core's balancer
- Fixed an issue where the RTP converter from listen only streams would be incorrectly released when the FS adapter was also used for full audio streams.