### PR TITLE
Version 2.2.4 with OAuth2/Streaming

### DIFF
--- a/config/client_secret.example.json
+++ b/config/client_secret.example.json
@@ -1,0 +1,16 @@
+{
+   "web": {
+      "client_id": "",
+      "project_id": "",
+      "auth_uri": "",
+      "token_uri": "",
+      "auth_provider_x509_cert_url": "",
+      "client_secret": "",
+      "redirect_uris": [
+         ""
+      ],
+      "javascript_origins": [
+         ""
+      ]
+   }
+}

--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -22,3 +22,7 @@ bbb-stream:
 
 recordWebcams: RECORD_WEBCAMS
 recordScreenSharing: RECORD_SCREENSHARE
+
+processes:
+  __name: SFU_PROCESSES
+  __format: json

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -79,7 +79,6 @@ processes:
 - path: ./lib/screenshare/ScreenshareProcess
 - path: ./lib/video/VideoProcess.js
 - path: ./lib/audio/AudioProcess.js
-- path: ./lib/stream/StreamProcess.js
 media-server-adapters:
 - path: kurento/kurento.js
   name: Kurento

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -51,6 +51,9 @@ bbb-stream:
   container_type: docker
   bigbluebutton_url: BBBHOST
   bigbluebutton_secret: BBBSECRET
+  bot_join_options:
+    userdata-html5autoswaplayout: false
+    userdata-html5hidepresentation: false
   k8s:
     namespace: default
     template:

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -62,6 +62,8 @@ const config = require('config');
         MEETING_STREAM_STARTED_MESSAGE_2x: "MeetingStreamStarted",
         MEETING_STREAM_STOPPED_MESSAGE_2x: "MeetingStreamStopped",
 
+        MEETING_STREAM_OAUTH2_URL_MESSAGE_2x: "MeetingStreamOAuth2Url",
+        MEETING_STREAM_OAUTH2_DATA_MESSAGE_2x: 'MeetingStreamOAuth2Data',
         // Message identifiers 1x
         START_TRANSCODER_REQUEST: "start_transcoder_request_message",
         START_TRANSCODER_REPLY: "start_transcoder_reply_message",
@@ -162,6 +164,9 @@ const config = require('config');
         STREAM_STARTED: 'started',
         STREAM_STOPPED: 'stopped',
         STREAMING_TYPE: 'streamType',
+        STREAM_OAUTH2_URL: 'oauth2url',
+        STREAM_OAUTH2_KEY: 'streamKey',
+        STREAM_OAUTH2_ID: 'streamId',
         STREAMING_STREAM_URL: 'streamUrl',
 
         // Log prefixes

--- a/lib/bbb/messages/Messaging.js
+++ b/lib/bbb/messages/Messaging.js
@@ -35,6 +35,8 @@ let UserDisconnectedFromGlobalAudio2x =
     require('./audio/UserDisconnectedFromGlobalAudio2x.js')(Constants);
 
 let StreamEventMessage2x = require('./stream/StreamEventMessage.js')(Constants);
+let StreamOAuth2UrlMessage2x = require('./stream/StreamOAuth2UrlMessage.js')(Constants);
+let StreamOAuth2DataMessage2x = require('./stream/StreamOAuth2DataMessage.js')(Constants);
 
  /**
   * @classdesc
@@ -126,6 +128,18 @@ Messaging.prototype.generateUserDisconnectedFromGlobalAudioMessage =
 Messaging.prototype.generateStreamEventMessage =
   function(meeting, state, streamUrl, streamType) {
     let msg = new StreamEventMessage2x(meeting, state, streamUrl, streamType);
+    return msg.toJson();
+}
+
+Messaging.prototype.generateStreamOAuth2UrlMessage =
+  function(meetingId, userId, url) {
+    let msg = new StreamOAuth2UrlMessage2x(meetingId, userId, url);
+    return msg.toJson();
+}
+
+Messaging.prototype.generateStreamOAuth2DataMessage =
+  function(meetingId, userId, key, id) {
+    let msg = new StreamOAuth2DataMessage2x(meetingId, userId, key, id);
     return msg.toJson();
 }
 

--- a/lib/bbb/messages/stream/StreamOAuth2DataMessage.js
+++ b/lib/bbb/messages/stream/StreamOAuth2DataMessage.js
@@ -1,0 +1,20 @@
+/*
+ * 
+ */
+
+var inherits = require('inherits');
+var OutMessage2x = require('../OutMessage2x');
+
+module.exports = function (C) {
+  function MeetingStreamOAuth2DataMessage2x (meetingId, userId, streamKey, streamId) {
+    const name = C.MEETING_STREAM_OAUTH2_DATA_MESSAGE_2x;
+    MeetingStreamOAuth2DataMessage2x.super_.call(this, name, {sender: 'bbb-webrtc-sfu'}, {meetingId, userId});
+
+    this.core.body = {};
+    this.core.body[C.STREAM_OAUTH2_KEY] = streamKey;
+    this.core.body[C.STREAM_OAUTH2_ID] = streamId;
+  };
+
+  inherits(MeetingStreamOAuth2DataMessage2x, OutMessage2x);
+  return MeetingStreamOAuth2DataMessage2x;
+}

--- a/lib/bbb/messages/stream/StreamOAuth2UrlMessage.js
+++ b/lib/bbb/messages/stream/StreamOAuth2UrlMessage.js
@@ -1,0 +1,19 @@
+/*
+ * 
+ */
+
+var inherits = require('inherits');
+var OutMessage2x = require('../OutMessage2x');
+
+module.exports = function (C) {
+  function MeetingStreamOAuth2UrlMessage2x (meetingId, userId, oauth2url) {
+    const name = C.MEETING_STREAM_OAUTH2_URL_MESSAGE_2x;
+    MeetingStreamOAuth2UrlMessage2x.super_.call(this, name, {sender: 'bbb-webrtc-sfu'}, {meetingId, userId});
+
+    this.core.body = {};
+    this.core.body[C.STREAM_OAUTH2_URL] = oauth2url;
+  };
+
+  inherits(MeetingStreamOAuth2UrlMessage2x, OutMessage2x);
+  return MeetingStreamOAuth2UrlMessage2x;
+}

--- a/lib/oauth2/server.js
+++ b/lib/oauth2/server.js
@@ -1,0 +1,156 @@
+const http = require('http')
+const fs = require('fs');
+const url = require('url');
+const querystring = require('querystring');
+
+const callbacks = {};
+const clients = {};
+
+const {google} = require('googleapis');
+const OAuth2 = google.auth.OAuth2;
+
+const SCOPES = ['https://www.googleapis.com/auth/youtube.readonly'];
+
+const SERVER_PORT = 8009;
+
+let client_secret = null;
+
+fs.readFile('client_secret.json', function processClientSecrets(err, content) {
+  if (err) {
+    console.log('Error loading client secret file: ' + err);
+    return;
+  }
+
+  client_secret = JSON.parse(content);
+});
+
+const getTokenUrl = (state, callback) => {
+
+  authorize(client_secret, (oauth2Client) => {
+
+    let authUrl = oauth2Client.generateAuthUrl({
+      access_type: 'offline',
+      scope: SCOPES,
+      prompt: 'consent',
+      state, 
+    });
+
+    return callback(oauth2Client, authUrl);
+  });
+
+}
+
+const getToken = (oauth2Client, code, callback) => {
+  oauth2Client.getToken(code, (err, token) => {
+    if (err) {
+      console.log('Error while trying to retrieve access token', err);
+      return;
+    }
+    oauth2Client.credentials = token;
+    callback(oauth2Client);
+  });
+}
+
+const authorize = (credentials, callback) => {
+  let clientSecret = credentials.web.client_secret;
+  let clientId = credentials.web.client_id;
+  let redirectUrl = credentials.web.redirect_uris[0];
+  let oauth2Client = new OAuth2(clientId, clientSecret, redirectUrl);
+
+  return callback(oauth2Client);
+}
+
+const getStreamKey = (auth, callback) => {
+  let service = google.youtube('v3');
+  service.liveBroadcasts.list({
+      auth,
+      part: 'id,snippet,contentDetails',
+      broadcastType: 'persistent',
+      mine: 'true',
+    }, (err, response) => {
+    if (err) {
+      console.log('The API returned an error: ' + err);
+      return callback(err);
+    }
+
+    let broadcast = response.data.items[0];
+
+    if (!broadcast) {
+      return callback('No broadcasts');
+    }
+
+    let videoId = broadcast.id;
+    let boundId = broadcast.contentDetails.boundStreamId;
+
+    service.liveStreams.list({
+      auth,
+      part: 'id,snippet,cdn',
+      id: boundId,
+    }, (err, response) => {
+      if (err) {
+        console.log('The API returned an error: ' + err);
+        return callback(err);
+      }
+      let stream = response.data.items[0];
+
+      if (!stream) {
+        return callback('No streams');
+      }
+
+      let prefix = stream.cdn.ingestionInfo.ingestionAddress;
+      let key = stream.cdn.ingestionInfo.streamName;
+
+      return callback(null, `${prefix}/${key}`, videoId);
+    });
+  });
+}
+
+const getStreamUrl = () => {
+
+};
+
+const server = http.createServer((req, res) => {
+  let parsedUrl = url.parse(req.url, true);
+  let state = parsedUrl.query.state;
+  let code = parsedUrl.query.code;
+  // let callback = callbacks[meetingId + userId];
+  let callback = callbacks[state];
+  let client = clients[state];
+
+  if (callback && client) {
+    client.getToken(code, (err, token) => {
+      if (err) {
+        console.log('Error while trying to retrieve access token', err);
+        return callback(null);
+      }
+
+      client.credentials = token;
+      return callback(client);
+    });
+  }
+
+  res.writeHead(200, { 'Content-Type': 'text/html' });
+  res.end('');
+});
+
+server.listen(SERVER_PORT);
+
+const onToken = (meetingId, userId, client, callback) => {
+  let id = meetingId + userId;
+
+  if (!callbacks[id]) {
+    callbacks[id] = callback;
+  }
+
+  if (!clients[id]) {
+    clients[id] = client;
+  }
+};
+
+
+module.exports = {
+  onToken,
+  getTokenUrl,
+  getStreamUrl,
+  getStreamKey,
+}

--- a/lib/stream/StreamManager.js
+++ b/lib/stream/StreamManager.js
@@ -16,6 +16,8 @@ const errors = require('../base/errors');
 
 const Messaging = require('../bbb/messages/Messaging');
 
+const OAuth2 = require('../oauth2/server');
+
 module.exports = class StreamManager extends BaseManager {
   constructor (connectionChannel, additionalChannels, logPrefix) {
     super(connectionChannel, additionalChannels, logPrefix);
@@ -24,6 +26,23 @@ module.exports = class StreamManager extends BaseManager {
     this._trackMeetingTermination();
     this.messageFactory(this._onMessage);
   }
+
+  _getOAuth2Url(meetingId, userId, callback) {
+    let id = meetingId + userId;
+    OAuth2.getTokenUrl(id, (client, url) => {
+
+      callback(url);
+
+      OAuth2.onToken(meetingId, userId, client, (auth) => {
+        OAuth2.getStreamKey(auth, (err, key, videoId) => {
+          Logger.info(this._logPrefix, 'Sharing oauth data for ', userId, key, videoId);
+          this._bbbGW.publish(
+            Messaging.generateStreamOAuth2DataMessage(meetingId, userId, key, videoId), C.TO_HTML5);
+        });
+
+      });
+    });
+  };
 
   _trackMeetingTermination () {
     switch (C.COMMON_MESSAGE_VERSION) {
@@ -86,6 +105,9 @@ module.exports = class StreamManager extends BaseManager {
 
         if (!session) {
           session = new Stream(this._bbbGW, meetingId, confname, streamUrl);
+        } else {
+          Logger.warn(this._logPrefix, "Not starting stream again for ", meetingId);
+          return;
         }
 
         this._meetings[meetingId] = meetingId;
@@ -105,39 +127,53 @@ module.exports = class StreamManager extends BaseManager {
 
           session.onStop(this._onStop(meetingId));
 
-	  Logger.info(this._logPrefix, "Sending startResponse to meeting ", meetingId, "for connection", session._id);
+          Logger.info(this._logPrefix, "Sending startResponse to meeting ", meetingId, "for connection", session._id);
         });
         break;
 
       case 'StopStream':
         Logger.info(this._logPrefix, 'Received stop mey10yssage for session', meetingId);
 
-	try {
+        try {
           if (session) {
 
             session.stop();
 
-	  } else {
+          } else {
             Logger.warn(this._logPrefix, "There was no stream session on stop for", meetingId);
-	    this._onStop(meetingId)();
+            this._onStop(meetingId)();
           }
-	} catch (err) {
+        } catch (err) {
           Logger.error(this._logPrefix, "Error stopping session for ", meetingId, err);
-	}
+        }
         break;
 
       case 'StreamKeepAlive':
         Logger.info(this._logPrefix, 'Received ping  for session', meetingId);
 
-	try {
+        try {
           if (session) {
             session.ping();
           } else {
             Logger.warn(this._logPrefix, 'Could not find session for pinging', meetingId);
-	  }
-	} catch (err) {
+          }
+        } catch (err) {
           Logger.error(this._logPrefix, "Error pinging session for ", meetingId, err);
-	}
+        }
+        break;
+
+      case 'GetOAuth2Url':
+        Logger.info(this._logPrefix, 'Received request for OAuth2 auth URL');
+
+        try {
+          this._getOAuth2Url(meetingId, userId, (url) => {
+            Logger.info(this._logPrefix, 'Sharing oauth url for ', meetingId, ' url is ', url);
+            this._bbbGW.publish(
+              Messaging.generateStreamOAuth2UrlMessage(meetingId, userId, url), C.TO_HTML5);
+          });
+        } catch (err) {
+          Logger.error(this._logPrefix, "Error oauth2 in session ", meetingId, err);
+        }
         break;
 
       default:

--- a/lib/stream/containers/docker.js
+++ b/lib/stream/containers/docker.js
@@ -15,20 +15,24 @@ module.exports = class DockerSpawner {
   }
 
   startContainer(link, streamUrl) {
-    docker.container.create({
-      Image: this.imageName,
-      Env: [ `LINK=${link}`, `OUTPUT=${streamUrl}`, `FORMAT=rtmp` ]
-    })
-    .then((c) => {
-      this.container = c;
-      Logger.debug(LOG_PREFIX, 'Created container', c.id);
-      c.start();
-      return c;
-     })
-    .then(() => {
-      this.setupEvents();
-    })
-    .catch(error => Logger.error(error));
+
+    try {
+      docker.container.create({
+        Image: this.imageName,
+        Env: [ `LINK=${link}`, `OUTPUT=${streamUrl}`, `FORMAT=rtmp` ]
+      })
+      .then((c) => {
+        this.container = c;
+        Logger.debug(LOG_PREFIX, 'Created container', c.id);
+        c.start();
+        return c;
+       })
+      .then(() => {
+        this.setupEvents();
+      });
+    } catch(error) {
+      Logger.error(error);
+    }
   }
 
   stopContainer() {
@@ -41,20 +45,21 @@ module.exports = class DockerSpawner {
 
     const promisifyStream = stream => new Promise((resolve, reject) => {
       stream.on('data', (data) => {
-	let dataJson = JSON.parse(data.toString());
+        let dataJson = JSON.parse(data.toString());
 
-	if (dataJson.id == this.container.id) {
-	  Logger.debug('Container message', dataJson.status);
+        if (dataJson.id == this.container.id) {
+          Logger.debug('Container message', dataJson.status);
 
-	  if (dataJson.status == 'die') {
-	    this.containerDied = true;
-	    this.process.onStopCallback(dataJson);
-	  }
+          if (dataJson.status == 'die') {
+            this.containerDied = true;
+            this.process.onStopCallback(dataJson);
+          }
 
-	  // Let's start when the bot is actually in the room
-	  if (dataJson.status == 'start') {
-	  }
-	}
+          // Let's start when the bot is actually in the room
+          if (dataJson.status == 'start') {
+            // TODO: do we need to do anything when the container starts?
+          }
+        }
       });
     });
 

--- a/lib/stream/containers/kubernetes.js
+++ b/lib/stream/containers/kubernetes.js
@@ -44,17 +44,19 @@ module.exports = class KubernetesSpawner {
 
     this.jobName = jobObject.metadata.name;
 
-    await this._setupEvents();
+    try {
+      await this._setupEvents();
 
-    await k8sJobsApi.createNamespacedJob(jobNamespace, jobObject)
-    .then((res) => {
-      this.uid = res.body.metadata.uid;
-      this.running = true;
-    })
-    .catch((err) => {
+      return k8sJobsApi.createNamespacedJob(jobNamespace, jobObject)
+      .then((res) => {
+        this.uid = res.body.metadata.uid;
+        this.running = true;
+      })
+    } catch(err) {
       Logger.error(LOG_PREFIX, 'ERROR creating container');
       this.process.onStopCallback(err);
-    });
+      return Promise.reject();
+    }
   }
 
   stopContainer() {
@@ -64,48 +66,51 @@ module.exports = class KubernetesSpawner {
       force: true
     };
 
-    return k8sJobsApi.deleteNamespacedJob(this.jobName, jobNamespace, options, null, null, 0).then(() => {
-      Logger.info(LOG_PREFIX, "Deleted stream job", this.jobName);
+    try {
+      return k8sJobsApi.deleteNamespacedJob(this.jobName, jobNamespace, options, null, null, 0).then(() => {
+        Logger.info(LOG_PREFIX, "Deleted stream job", this.jobName);
 
-      this.running = false;
+        this.running = false;
 
-      k8sPodsApi.deleteNamespacedPod(this.podName, jobNamespace, options, null, null, 0)
-      .then((res) => {
-	Logger.info(LOG_PREFIX, "Successfully delete container", this.podName); 
-        this._abortEvents();
-      }).
-      catch((err) => {
-        this._abortEvents();
+        k8sPodsApi.deleteNamespacedPod(this.podName, jobNamespace, options, null, null, 0)
+        .then((res) => {
+          Logger.info(LOG_PREFIX, "Successfully deleted container", this.podName);
+          this._abortEvents();
+        });
       });
-    })
-    .catch((err) => {
+    } catch(err) {
       Logger.error(LOG_PREFIX, "Problem deleting container", err);
       this._abortEvents();
-    });
+      return Promise.reject();
+    }
   }
 
   async _setupEvents() {
     let eventStream = (type, obj) => {
       if (!this.running && type !== 'DELETED') {
         Logger.info(LOG_PREFIX, "Ignoring events because it's not running anymore");
-	return;
+        return;
       }
 
-      // console.log(obj);
-      if (type == 'ADDED') {
-        if (obj.kind == 'Pod' && (this.jobName + '-') === obj.metadata.generateName) {
-	  this.podName = obj.metadata.name;
-	}
-      } else if (type == 'MODIFIED') {
-        //
-      } else if (type == 'DELETED') {
-        //
-	if (obj.kind == 'Job' && this.jobName === obj.metadata.name) {
-          Logger.info(LOG_PREFIX, 'Send post-stop callback');
-          this.process.onStopCallback();
-        }
-      } else {
-        Logger.error(LOG_PREFIX, 'unknown type: ' + type);
+      switch (type) {
+        case 'ADDED':
+          if (obj.kind == 'Pod' && obj.metadata.generateName.includes(this.jobName)) {
+            this.podName = obj.metadata.name;
+          }
+          break;
+
+        case 'DELETED':
+          if (obj.kind == 'Job' && this.jobName === obj.metadata.name) {
+            Logger.info(LOG_PREFIX, 'Send post-stop callback');
+            this.process.onStopCallback();
+          }
+          break;
+
+        case 'MODIFIED':
+          break;
+
+        default:
+          Logger.error(LOG_PREFIX, 'unknown type: ' + type);
       }
     };
     let errFunc = (err) => {

--- a/lib/stream/stream.js
+++ b/lib/stream/stream.js
@@ -18,7 +18,9 @@ const MAX_MISSED_KEEPALIVES = 3;
 let getJoinUrl = (server, meetingId) => {
 
   let room = server.monitoring.getMeetingInfo(meetingId);
-  let options = {
+  let options = config.has('bbb-stream.bot_join_options') ? config.get('bbb-stream.bot_join_options') : {};
+
+  options = {...options,
     'userdata-html5recordingbot': true,
     'joinViaHtml5': true
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,14 @@
         }
       }
     },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "ajv": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
@@ -187,6 +195,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -282,6 +299,11 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "bufferutil": {
       "version": "1.2.1",
@@ -550,6 +572,14 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -577,6 +607,14 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
       "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -755,6 +793,24 @@
         "pinkie-promise": "^2.0.0"
       }
     },
+    "follow-redirects": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -790,6 +846,26 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "gaxios": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.2.7.tgz",
+      "integrity": "sha512-E0tFhk7gqyLReJeBE/APaokrVNJ9zVHuuBKNTXTRhfItUhV0pW42NzzOJiK5kKup/4R+2e/SXJRRp2LT5huF8Q==",
+      "requires": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^2.2.1",
+        "node-fetch": "^2.2.0"
+      }
+    },
+    "gcp-metadata": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.7.0.tgz",
+      "integrity": "sha512-ffjC09amcDWjh3VZdkDngIo7WoluyC5Ag9PAYxZbmQLOLNI8lvPtoKTSCyU54j2gwy5roZh6sSMTfkY2ct7K3g==",
+      "requires": {
+        "axios": "^0.18.0",
+        "extend": "^3.0.1",
+        "retry-axios": "0.3.2"
+      }
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -816,10 +892,105 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "google-auth-library": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-2.0.1.tgz",
+      "integrity": "sha512-CWLKZxqYw4SE+fE3GWbVT9r/10h75w8lB3cdmmLpLtCfccFDcsI84qI5rx7npemlrHtKJh3C2HUz4s6SihCeIQ==",
+      "requires": {
+        "axios": "^0.18.0",
+        "gcp-metadata": "^0.7.0",
+        "gtoken": "^2.3.0",
+        "https-proxy-agent": "^2.2.1",
+        "jws": "^3.1.5",
+        "lodash.isstring": "^4.0.1",
+        "lru-cache": "^4.1.3",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.3.tgz",
+      "integrity": "sha512-KGnAiMMWaJp4j4tYVvAjfP3wCKZRLv9M1Nir2wRRNWUYO7j1aX8O9Qgz+a8/EQ5rAvuo4SIu79n6SIdkNl7Msg==",
+      "requires": {
+        "node-forge": "^0.7.5",
+        "pify": "^4.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        }
+      }
+    },
+    "googleapis": {
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-35.0.0.tgz",
+      "integrity": "sha512-HseVyK5CVwFM+x+uHqkbKxDRuaMVkYyfAM7Buz3X44/BglHWtzOrtffRVoQORLQHVf4kzhJcjmUvVTwfOG6klA==",
+      "requires": {
+        "google-auth-library": "^2.0.0",
+        "googleapis-common": "^0.4.0"
+      }
+    },
+    "googleapis-common": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-0.4.0.tgz",
+      "integrity": "sha512-G8U5eUhmCzvZa80BtfcL2ECPiIJxmJYsPPIY3/9iODrIvDkY75wtxnEobG7HDUprtn/3Es6mP6KevqNZ5u6t4g==",
+      "requires": {
+        "axios": "^0.18.0",
+        "google-auth-library": "^2.0.0",
+        "pify": "^4.0.0",
+        "qs": "^6.5.2",
+        "url-template": "^2.0.8",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+    },
+    "gtoken": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.2.tgz",
+      "integrity": "sha512-F8EObUGyC8Qd3WXTloNULZBwfUsOABoHElihB1F6zGhT/cy38iPL09wGLRY712I+hQnOyA+sYlgPFX2cOKz0qg==",
+      "requires": {
+        "gaxios": "^1.0.4",
+        "google-p12-pem": "^1.0.0",
+        "jws": "^3.1.5",
+        "mime": "^2.2.0",
+        "pify": "^4.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+          "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -867,6 +1038,30 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "iconv-lite": {
@@ -1104,6 +1299,25 @@
         "promise": "^7.0.1"
       }
     },
+    "jwa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.2.0.tgz",
+      "integrity": "sha512-Grku9ZST5NNQ3hqNUodSkDfEBqAmGA1R8yiyPHOnLzEKI0GaCQC/XhFmsheXYuXzFQJdILbh+lYBiliqG5R/Vg==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.10",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz",
+      "integrity": "sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==",
+      "requires": {
+        "jwa": "^1.2.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -1257,6 +1471,11 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -1391,6 +1610,16 @@
         "docker-modem": "^0.3.1",
         "memorystream": "^0.3.1"
       }
+    },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+    },
+    "node-forge": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
     "node-redis-scripty": {
       "version": "0.0.5",
@@ -1614,6 +1843,11 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.1.29",
@@ -1932,6 +2166,11 @@
       "requires": {
         "path-parse": "^1.0.5"
       }
+    },
+    "retry-axios": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
+      "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
     },
     "right-align": {
       "version": "0.1.3",
@@ -2385,6 +2624,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    },
     "utf-8-validate": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.2.2.tgz",
@@ -2598,6 +2842,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
       "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "4.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "private": true,
   "scripts": {
     "start": "node server.js"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "bbb-promise": "1.1.0",
     "config": "1.30.0",
     "esl": "9.0.1",
+    "google-auth-library": "2.0.1",
+    "googleapis": "35.0.0",
     "js-yaml": "3.11.0",
     "kue": "0.11.6",
     "kurento-client": "git+https://github.com/mconf/kurento-client-js.git#mconf",


### PR DESCRIPTION
Replaces #4.

CHANGELOG:

- Added support for streaming with authentication via OAuth2 (@lfzawacki). 
```
This could be extended to other streaming providers that can log you via OAuth2, 
but for now it works with the Google API to get data from the users youtube account. 
Here's a private gist with configuration instructions: 
  https://gist.github.com/lfzawacki/c24f6b073754644d36b9ad73e2306fb5
```
- Disabled the `streaming` module by default and included a custom env var to specify the modules which the component should start (`SFU_PROCESS`)