### PR TITLE
Implemented the changes done in the mcs-core API's floor methods

### DIFF
--- a/lib/base/MCSAPIWrapper.js
+++ b/lib/base/MCSAPIWrapper.js
@@ -225,21 +225,20 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
 
   async getContentFloor (roomId) {
     try {
-
       const ret = await this._mcs.getContentFloor(roomId);
-      return  ret.mediaId;
+      return ret;
     }
     catch (error) {
       throw (this._handleError(error, 'getContentFloor', { roomId }));
     }
   }
 
-  async releaseContentFloor (roomId, mediaId) {
+  async releaseContentFloor (roomId) {
     try {
-      return this._mcs.releaseContentFloor(roomId, mediaId);
+      return this._mcs.releaseContentFloor(roomId);
     }
     catch (error) {
-      throw (this._handleError(error, 'releaseContentFloor', { roomId, mediaId }));
+      throw (this._handleError(error, 'releaseContentFloor', { roomId }));
     }
   }
 
@@ -253,12 +252,12 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
     }
   }
 
-  async releaseConferenceFloor(roomId, mediaId) {
+  async releaseConferenceFloor(roomId) {
     try {
-      return this._mcs.releaseConferenceFloor(roomId, mediaId);
+      return this._mcs.releaseConferenceFloor(roomId);
     }
     catch (error) {
-      throw (this._handleError(error, 'releaseConferenceFloor', { roomId, mediaId }));
+      throw (this._handleError(error, 'releaseConferenceFloor', { roomId }));
     }
   }
 

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -227,8 +227,8 @@ const MR = class MCSRouter {
   async setConferenceFloor(args) {
     try {
       const { mediaId, roomId } = args
-      const mediaInfo = await this._mediaController.setConferenceFloor(roomId, mediaId)
-      return mediaInfo;
+      const floorInfo = await this._mediaController.setConferenceFloor(roomId, mediaId)
+      return floorInfo;
     }
     catch (error) {
       throw (this._handleError(error, 'setConferenceFloor', {}))
@@ -238,8 +238,8 @@ const MR = class MCSRouter {
   async setContentFloor(args) {
     try {
       const { roomId, mediaId } = args
-      const mediaInfo = await this._mediaController.setContentFloor(roomId, mediaId)
-      return mediaInfo;
+      const floorInfo = await this._mediaController.setContentFloor(roomId, mediaId)
+      return floorInfo;
     }
     catch (error) {
       throw (this._handleError(error, 'setContentFloor', {}))
@@ -248,8 +248,9 @@ const MR = class MCSRouter {
 
   async releaseConferenceFloor(args) {
     try {
-      const { mediaId, roomId } = args
-      await this._mediaController.releaseConferenceFloor(roomId, mediaId)
+      const { roomId } = args
+      const previousFloor = await this._mediaController.releaseConferenceFloor(roomId)
+      return previousFloor;
     }
     catch (error) {
       throw (this._handleError(error, 'releaseConferenceFloor', {}))
@@ -258,8 +259,9 @@ const MR = class MCSRouter {
 
   async releaseContentFloor(args) {
     try {
-      const { roomId, mediaId } = args
-      await this._mediaController.releaseContentFloor(roomId, mediaId)
+      const { roomId } = args
+      const previousFloor = await this._mediaController.releaseContentFloor(roomId)
+      return previousFloor;
     }
     catch (error) {
       throw (this._handleError(error, 'releaseContentFloor', {}))
@@ -269,8 +271,8 @@ const MR = class MCSRouter {
   async getConferenceFloor(args) {
     const { roomId } = args
     try {
-      const mediaId = await this._mediaController.getConferenceFloor(roomId)
-      return mediaId;
+      const floorInfo = await this._mediaController.getConferenceFloor(roomId)
+      return floorInfo;
     }
     catch (error) {
       throw (this._handleError(error, 'getConferenceFloor', {}))
@@ -280,8 +282,8 @@ const MR = class MCSRouter {
   async getContentFloor(args) {
     const { roomId } = args
     try {
-      const mediaId = await this._mediaController.getContentFloor(roomId)
-      return mediaId;
+      const floorInfo = await this._mediaController.getContentFloor(roomId)
+      return floorInfo;
     }
     catch (error) {
       throw (this._handleError(error, 'getContentFloor', {}))
@@ -558,8 +560,8 @@ const MR = class MCSRouter {
       let transactionId, mediaId, roomId;
       try {
         ({transactionId, mediaId, roomId } = args);
-        const media = await this.setConferenceFloor(args)
-        client.conferenceFloorChanged(roomId, media, {transactionId})
+        const { floor, previousFloor } = await this.setConferenceFloor(args)
+        client.conferenceFloorChanged(roomId, { floor, previousFloor, transactionId })
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -570,8 +572,8 @@ const MR = class MCSRouter {
       let transactionId, mediaId, roomId;
       try {
         ({ transactionId, mediaId, roomId } = args);
-        const media = await this.setContentFloor(args)
-        client.contentFloorChanged(roomId, media, {transactionId})
+        const { floor, previousFloor } = await this.setContentFloor(args)
+        client.contentFloorChanged(roomId, { floor, previousFloor, transactionId })
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -579,11 +581,11 @@ const MR = class MCSRouter {
     });
 
     client.on('releaseConferenceFloor', async (args) => {
-      let transactionId, mediaId, roomId;
+      let transactionId, roomId;
       try {
-        ({ transactionId, mediaId, roomId} = args);
-        const media = await this.releaseConferenceFloor(args)
-        client.conferenceFloorChanged(roomId, {}, {transactionId})
+        ({ transactionId, roomId} = args);
+        const previousFloor = await this.releaseConferenceFloor(args)
+        client.conferenceFloorChanged(roomId, { previousFloor, transactionId })
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -591,11 +593,11 @@ const MR = class MCSRouter {
     });
 
     client.on('releaseContentFloor', async (args) =>{
-      let transactionId, mediaId, roomId;
+      let transactionId, roomId;
       try {
-        ({ transactionId, mediaId, roomId} = args);
-        await this.releaseContentFloor(args)
-        client.contentFloorChanged(roomId, {}, {transactionId})
+        ({ transactionId, roomId} = args);
+        const previousFloor = await this.releaseContentFloor(args)
+        client.contentFloorChanged(roomId, { previousFloor, transactionId })
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -606,8 +608,8 @@ const MR = class MCSRouter {
       let transactionId, roomId;
       try {
         ({ transactionId, roomId } = args);
-        const mediaId = await this.getContentFloor(args)
-        client.contentFloor(roomId, mediaId, {transactionId})
+        const { floor, previousFloor }  = await this.getContentFloor(args)
+        client.contentFloor(roomId, { floor, previousFloor, transactionId })
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -618,8 +620,8 @@ const MR = class MCSRouter {
       let transactionId, roomId;
       try {
         ({ transactionId, roomId } = args);
-        const mediaId = await this.getConferenceFloor(args)
-        client.conferenceFloor(roomId, mediaId, {transactionId})
+        const { floor, previousFloor } = await this.getConferenceFloor(args)
+        client.conferenceFloor(roomId, { floor, previousFloor, transactionId})
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -799,23 +801,23 @@ const MR = class MCSRouter {
     });
 
     this.emitter.on(C.EVENT.CONTENT_FLOOR_CHANGED, event => {
-      const { roomId, media } = event;
+      const { roomId, floor, previousFloor } = event;
       const clients = this._getClientToDispatch(roomId, C.EVENT.CONTENT_FLOOR_CHANGED);
 
       if (clients.length > 0) {
         clients.forEach(client => {
-          client.contentFloorChanged(roomId, media);
+          client.contentFloorChanged(roomId, { floor, previousFloor });
         })
       }
     });
 
     this.emitter.on(C.EVENT.CONFERENCE_FLOOR_CHANGED, event => {
-      const { roomId, media } = event;
+      const { roomId, floor, previousFloor } = event;
       const clients = this._getClientToDispatch(roomId, C.EVENT.CONFERENCE_FLOOR_CHANGED);
 
       if (clients.length > 0) {
         clients.forEach(client => {
-          client.conferenceFloorChanged(roomId, media);
+          client.conferenceFloorChanged(roomId, { floor, previousFloor });
         })
       }
     });

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -508,7 +508,6 @@ module.exports = class MediaController {
       try {
         const room = await this.getRoom(roomId);
         const media = this.getMediaSession(mediaId);
-        Logger.info(LOG_PREFIX, 'Fetched room', room.id, 'and media', media.id);
         const mediaInfo = room.setContentFloor(media);
         resolve(mediaInfo);
       }
@@ -523,7 +522,6 @@ module.exports = class MediaController {
       try {
         const room = await this.getRoom(roomId);
         const media = this.getMediaSession(mediaId);
-        Logger.info(LOG_PREFIX, 'Fetched room', room.id, 'and media', media.id);
         const mediaInfo = room.setConferenceFloor(media);
         resolve(mediaInfo);
       }
@@ -533,12 +531,11 @@ module.exports = class MediaController {
     })
   }
 
-  releaseContentFloor(roomId, mediaId) {
+  releaseContentFloor(roomId) {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        Logger.info(LOG_PREFIX, 'Fetched room', room.id);
-        room.releaseContentFloor(mediaId);
+        room.releaseContentFloor();
         resolve();
       }
       catch (error) {
@@ -547,12 +544,11 @@ module.exports = class MediaController {
     })
   }
 
-  releaseConferenceFloor(roomId, mediaId) {
+  releaseConferenceFloor(roomId) {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        Logger.info(LOG_PREFIX, 'Fetched room', room.id);
-        room.releaseConferenceFloor(mediaId);
+        room.releaseConferenceFloor();
         resolve();
       }
       catch (error) {
@@ -565,7 +561,6 @@ module.exports = class MediaController {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        Logger.info(LOG_PREFIX, 'Fetched room', room.id);
         resolve(room.getContentFloor());
       }
       catch (error) {

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -62,6 +62,7 @@ module.exports = class MediaSession {
       video: false,
       audio: false,
       text: false,
+      content: false,
       application: false,
       message: false,
     }
@@ -88,6 +89,9 @@ module.exports = class MediaSession {
         });
 
         this._status = C.STATUS.STOPPED;
+
+        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.id, mediaSessionId: this.mediaSessionId });
+
         return Promise.resolve();
       }
       catch (err) {
@@ -307,11 +311,11 @@ module.exports = class MediaSession {
     });
   }
 
-  getApplicationMedia () {
-    let applicationMedia = this.medias.find(m => m.mediaTypes.application && m.mediaTypes.application !== 'recvonly')
+  getContentMedia () {
+    let contentMedia = this.medias.find(m => m.mediaTypes.content && m.mediaTypes.content !== 'recvonly')
 
-    if (applicationMedia) {
-      return applicationMedia;
+    if (contentMedia) {
+      return contentMedia;
     }
 
     return this.medias.find(m => m.mediaTypes.video && m.mediaTypes.video !== 'recvonly');

--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -43,6 +43,7 @@ module.exports = class Media {
       video: false,
       audio: false,
       text: false,
+      content: false,
       application: false,
       message: false,
     }
@@ -103,7 +104,6 @@ module.exports = class Media {
 
     this.adapter.once(C.EVENT.MEDIA_DISCONNECTED+this.adapterElementId, this.stop.bind(this));
 
-
     Logger.info(LOG_PREFIX, "New media session", this.id, "in room", this.roomId, "started with media server endpoint", this.adapterElementId);
   }
 
@@ -123,7 +123,7 @@ module.exports = class Media {
 
         this.status = C.STATUS.STOPPED;
         Logger.info(LOG_PREFIX, "Session", this.id, "stopped with status", this.status);
-        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.mediaSessionId, mediaSessionId: this.mediaSessionId });
+        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.id, mediaSessionId: this.mediaSessionId });
 
         return Promise.resolve();
       }
@@ -320,6 +320,7 @@ module.exports = class Media {
 
   getMediaInfo () {
     const mediaInfo = {
+      mediaSessionId: this.mediaSessionId,
       mediaId: this.id,
       roomId: this.roomId,
       userId: this.userId,
@@ -372,7 +373,7 @@ module.exports = class Media {
     return this._subscribedTo;
   }
 
-  getApplicationMedia () {
+  getContentMedia () {
     return this;
   }
 

--- a/lib/mcs-core/lib/model/room.js
+++ b/lib/mcs-core/lib/model/room.js
@@ -15,7 +15,9 @@ module.exports = class Room {
     this.id = id;
     this._users = {};
     this._conferenceFloor;
+    this._previousConferenceFloors = [];
     this._contentFloor;
+    this._previousContentFloors = [];
     this._registeredEvents = [];
     this._trackContentMediaDisconnection();
     this._trackConferenceMediaDisconnection();
@@ -29,45 +31,81 @@ module.exports = class Room {
     return Object.keys(this._users).map(uk => this._users[uk].getUserInfo());
   }
 
-  getConferenceFloor () {
-    return this._conferenceFloor? this._conferenceFloor.id : null;
-  }
-
-  getContentFloor () {
-    return this._contentFloor? this._contentFloor.id : null;
-  }
-
   setUser (user) {
     this._users[user.id] = user;
     GLOBAL_EVENT_EMITTER.emit(C.EVENT.USER_JOINED, { roomId: this.id, user: user.getUserInfo() });
   }
 
+  getConferenceFloor () {
+    const conferenceFloorInfo = {
+      floor: this._conferenceFloor? this._conferenceFloor.getMediaInfo() : undefined,
+      previousFloor: this._previousConferenceFloors[0]? this._previousConferenceFloors[0].getMediaInfo() : undefined,
+    };
+
+    return conferenceFloorInfo;
+  }
+
+  getContentFloor () {
+    const contentFloorInfo = {
+      floor: this._contentFloor? this._contentFloor.getMediaInfo() : undefined,
+      previousFloor: this._previousContentFloors[0]? this._previousContentFloors[0].getMediaInfo() : undefined,
+    };
+
+    return contentFloorInfo;
+  }
+
+  _setPreviousConferenceFloor () {
+    this._previousConferenceFloors = this._previousConferenceFloors.filter(pcf => pcf.id !== this._conferenceFloor.id);
+    this._previousConferenceFloors.unshift(this._conferenceFloor);
+  }
+
   setConferenceFloor (media) {
+    if (this._conferenceFloor && this._previousConferenceFloor[0] && this._previousConferenceFloor[0].id !== this._conferenceFloor.id) {
+      this._setPreviousConferenceFloor();
+    }
+
     this._conferenceFloor = media;
-    const mediaInfo = media.getMediaInfo();
-    GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, media: mediaInfo});
-    return mediaInfo;
+    const conferenceFloorInfo = this.getConferenceFloor();
+    GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, ...conferenceFloorInfo });
+    return conferenceFloorInfo;
+  }
+
+  _setPreviousContentFloor () {
+    this._previousContentFloors = this._previousContentFloors.filter(pcf => pcf.id !== this._contentFloor.id);
+    this._previousContentFloors.unshift(this._contentFloor);
   }
 
   setContentFloor (media) {
-    this._contentFloor = media.getApplicationMedia();
-    const mediaInfo = this._contentFloor.getMediaInfo();
-    GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, media: mediaInfo});
-    return mediaInfo;
+    if (this._contentFloor && this._previousContentFloors[0] && this._previousContentFloors[0].id !== this._contentFloor.id) {
+      this._setPreviousContentFloor();
+    }
+
+    this._contentFloor = media.getContentMedia();
+    const contentFloorInfo = this.getContentFloor();
+    GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, ...contentFloorInfo });
+    return contentFloorInfo;
   }
 
   releaseConferenceFloor () {
-    if (this.getConferenceFloor()) {
+    if (this._conferenceFloor) {
+      this._setPreviousConferenceFloor();
       this._conferenceFloor = null
-      GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, media: {}});
+      const conferenceFloorInfo = this.getConferenceFloor();
+      GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, ...conferenceFloorInfo});
     }
+
+    return this._previousConferenceFloors[0];
   }
 
   releaseContentFloor () {
-    if (this.getContentFloor()) {
+    if (this._contentFloor) {
+      this._setPreviousContentFloor();
       this._contentFloor = null;
-      GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, media: {}}) ;
+      const contentFloorInfo = this.getContentFloor();
+      GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, ...contentFloorInfo }) ;
     }
+
+    return this._previousContentFloors[0];
   }
 
   _registerEvent (event, callback) {
@@ -79,10 +117,14 @@ module.exports = class Room {
     // Used when devices ungracefully disconnect from the system
     const clearContentFloor = (event) => {
       const { mediaId, roomId, mediaSessionId } = event;
-      const contentFloorId = this.getContentFloor();
+      if (roomId === this.id) {
+        const contentFloorId = this.getContentFloor();
 
-      if (roomId === this.id && (mediaId === contentFloorId || mediaSessionId === contentFloorId)) {
-        this.releaseContentFloor(contentFloorId);
+        if (mediaId === contentFloorId || mediaSessionId === contentFloorId) {
+          this.releaseContentFloor(contentFloorId);
+        }
+
+        this._previousContentFloors = this._previousContentFloors.filter(pcf => pcf.id !== mediaId);
       }
     };
 
@@ -95,10 +137,14 @@ module.exports = class Room {
     // Used when devices ungracefully disconnect from the system
     const clearConferenceFloor = (event) => {
       const { mediaId, roomId, mediaSessionId } = event;
-      const conferenceFloorId = this.getConferenceFloor();
+      if (roomId === this.id) {
+        const conferenceFloorId = this.getConferenceFloor();
 
-      if (roomId === this.id && (mediaId === conferenceFloorId || mediaSessionId === conferenceFloorId)) {
-        this.releaseConferenceFloor(conferenceFloorId);
+        if (roomId === this.id && (mediaId === conferenceFloorId || mediaSessionId === conferenceFloorId)) {
+          this.releaseConferenceFloor(conferenceFloorId);
+        }
+
+        this._previousConferenceFloors = this._previousConferenceFloors.filter(pcf => pcf.id !== mediaId);
       }
     };
 

--- a/lib/mcs-core/lib/model/sdp-media.js
+++ b/lib/mcs-core/lib/model/sdp-media.js
@@ -68,6 +68,7 @@ module.exports = class SDPMedia extends Media {
   fillMediaTypes () {
     this.mediaTypes.video = this.offer.hasAvailableVideoCodec() ? this.offer.getDirection('video') : false;
     this.mediaTypes.audio = this.offer.hasAvailableAudioCodec() ? this.offer.getDirection('audio') : false;
+    this.mediaTypes.content = this.offer.hasContent() ? this.offer.getDirection('content') : false;
   }
 
   addIceCandidate (candidate) {

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -89,6 +89,7 @@ module.exports = class SDPSession extends MediaSession {
           this.medias = this.medias.concat(contentMedias);
 
           const contentAnswer = this.getAnswer();
+          // TODO move the content:slides appendage to the kurento adapter
           this.setAnswer(contentAnswer + "a=content:slides\r\n");
           return resolve(contentAnswer + "a=content:slides\r\n");
         }

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -121,15 +121,28 @@ module.exports = class SdpWrapper {
   }
 
   getDirection (type) {
-    let direction;
-    const media = this._jsonSdp.media.find(m => m.type === type);
-    if (media == null || media.direction == null) {
-      direction = 'sendrecv';
-    } else  {
-      direction = media.direction;
+    let direction, media;
+    const fetchDirection = (m) => {
+      if (m == null || m.direction == null) {
+        return 'sendrecv';
+      } else  {
+        return media.direction;
+      }
     }
 
-    return direction
+    // If we're fetching the content direciton, we go for the video direction
+    // because it's the only media type currently supported for content
+    if (type === 'content') {
+      if (this.contentVideoSdp) {
+        const parsedContentSDP = transform.parse(this.contentVideoSdp);
+        media = parsedContentSDP.media.find(m => m.type === 'video');
+        return fetchDirection(media);
+      }
+      return false;
+    }
+
+    media = this._jsonSdp.media.find(m => m.type === type);
+    return fetchDirection(media);
   }
 
   /**
@@ -174,6 +187,12 @@ module.exports = class SdpWrapper {
       const hasContentSlides = ml.invalid? ml.invalid[0].value.includes('slides') : false;
       return ml.type === "video" && hasContentSlides;
     });
+
+    // No content:slides media in this one
+    if (res.media.length <= 0) {
+      return;
+    }
+
     var mangledSdp = transform.write(res);
     if(typeof mangledSdp != undefined && mangledSdp && mangledSdp != "") {
       return mangledSdp;
@@ -435,7 +454,6 @@ module.exports = class SdpWrapper {
 
     this._mediaCapabilities.hasVideo = this._hasVideo();
     this._mediaCapabilities.hasAudio = this._hasAudio();
-    this._mediaCapabilities.hasContent = this._hasMultipleVideo();
     this._mediaCapabilities.hasAvailableVideoCodec = this._hasAvailableVideoCodec();
     this._mediaCapabilities.hasAvailableAudioCodec = this._hasAvailableAudioCodec();
     this.sessionDescriptionHeader = SdpWrapper.getSessionDescription(description);
@@ -443,6 +461,7 @@ module.exports = class SdpWrapper {
     this.mainVideoSdp = this.getMainDescription(description);
     this.partialDescriptors = SdpWrapper.getPartialDescriptions(description);
     this.contentVideoSdp = this.getContentDescription(description);
+    this._mediaCapabilities.hasContent = this.contentVideoSdp? true : false;
 
     return;
   }

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -302,6 +302,17 @@ module.exports = class Screenshare extends BaseProvider {
     }
   }
 
+  async _fetchContentFloor () {
+    try {
+      const { floor } = await this.mcs.getContentFloor(this._voiceBridge);
+      const contentFloorId = floor.mediaId;
+      Logger.debug(LOG_PREFIX, "Content floor for", this._voiceBridge, "is", contentFloorId);
+      return contentFloorId;
+    } catch (e) {
+      throw e;
+    }
+  }
+
   async _upstartRTPStream () {
     try {
       const sendVideoPort = MediaHandler.getVideoPort();
@@ -313,8 +324,7 @@ module.exports = class Screenshare extends BaseProvider {
       }
 
       if (this._presenterEndpoint == null) {
-        const contentFloorId = await this.mcs.getContentFloor(this._voiceBridge);
-        this._presenterEndpoint = contentFloorId;
+        this._presenterEndpoint = await this._fetchContentFloor();;
       }
 
       const { mediaId, answer } = await this.mcs.subscribe(this.mcsUserId,
@@ -354,8 +364,7 @@ module.exports = class Screenshare extends BaseProvider {
         }
 
         if (this._presenterEndpoint == null) {
-          const contentFloorId = await this.mcs.getContentFloor(this._voiceBridge);
-          this._presenterEndpoint = contentFloorId;
+          this._presenterEndpoint = await this._fetchContentFloor();
         }
 
         const { mediaId, answer } = await this.mcs.subscribe(this.mcsUserId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1487,8 +1487,8 @@
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "mcs-js": {
-      "version": "git+https://github.com/mconftec/mcs-js.git#8459420b4fd25261ee02e7823f47565b55b50727",
-      "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.3-dev",
+      "version": "git+https://github.com/mconftec/mcs-js.git#3f54e5eacf970b099ebffd0b738f48de2d6886b7",
+      "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.4-dev",
       "requires": {
         "uuid": "3.3.2",
         "ws": "6.1.2"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "js-yaml": "3.11.0",
     "kue": "0.11.6",
     "kurento-client": "git+https://github.com/mconf/kurento-client-js.git#mconf",
-    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.3-dev",
+    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.4-dev",
     "node-docker-api": "1.1.22",
     "readable-id": "1.0.0",
     "redis": "2.8.0",


### PR DESCRIPTION
- Follow the changes done on https://github.com/mconftec/mcs-js/pull/11. I did this to facilitate client usage of the floor methods and floor tracking on their sides without having to keep state. Also standardized the way the floor methods were used and parameterized and we now provide a way to safely detect when there's no more content in the room;
- Fixed an issue while parsing for content SDPs;
- Correctly fill the content media type and decouple it from application (now unused);
- Bump mcs-js version to v0.0.4-dev.