### PR TITLE
Version 2.3.0

### DIFF
--- a/lib/base/MCSAPIWrapper.js
+++ b/lib/base/MCSAPIWrapper.js
@@ -225,21 +225,20 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
 
   async getContentFloor (roomId) {
     try {
-
       const ret = await this._mcs.getContentFloor(roomId);
-      return  ret.mediaId;
+      return ret;
     }
     catch (error) {
       throw (this._handleError(error, 'getContentFloor', { roomId }));
     }
   }
 
-  async releaseContentFloor (roomId, mediaId) {
+  async releaseContentFloor (roomId) {
     try {
-      return this._mcs.releaseContentFloor(roomId, mediaId);
+      return this._mcs.releaseContentFloor(roomId);
     }
     catch (error) {
-      throw (this._handleError(error, 'releaseContentFloor', { roomId, mediaId }));
+      throw (this._handleError(error, 'releaseContentFloor', { roomId }));
     }
   }
 
@@ -253,12 +252,12 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
     }
   }
 
-  async releaseConferenceFloor(roomId, mediaId) {
+  async releaseConferenceFloor(roomId) {
     try {
-      return this._mcs.releaseConferenceFloor(roomId, mediaId);
+      return this._mcs.releaseConferenceFloor(roomId);
     }
     catch (error) {
-      throw (this._handleError(error, 'releaseConferenceFloor', { roomId, mediaId }));
+      throw (this._handleError(error, 'releaseConferenceFloor', { roomId }));
     }
   }
 

--- a/lib/base/MCSAPIWrapper.js
+++ b/lib/base/MCSAPIWrapper.js
@@ -60,12 +60,14 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
       this._reconnectionRoutine = null;
     }
 
+    this.emit(C.MCS_CONNECTED);
     this._connectionResolver();
   }
 
   async _onDisconnection () {
     // TODO base reconenction, should be ane exponential backoff
     if (this._reconnectionRoutine == null) {
+      this.emit(C.MCS_DISCONNECTED);
       this._reconnectionRoutine = setInterval(async () => {
         try {
           Logger.info("[sfu-mcs-api] Connecting to MCS at", this.addr);

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -182,12 +182,16 @@ const config = require('config');
         AUDIO_PROCESS_PREFIX: '[AudioProcess]',
         AUDIO_MANAGER_PREFIX: '[AudioManager]',
         AUDIO_PROVIDER_PREFIX: '[AudioProvider]',
-	STREAM_PROCESS_PREFIX: '[StreamProcess]',
+        STREAM_PROCESS_PREFIX: '[StreamProcess]',
         STREAM_MANAGER_PREFIX: '[StreamManager]',
-	STREAM_PROVIDER_PREFIX: '[StreamProvider]',
+        STREAM_PROVIDER_PREFIX: '[StreamProvider]',
 
-	// MCS error codes
+        // MCS error codes
         MEDIA_SERVER_OFFLINE: 2001,
+
+        // MCS Wrapper events
+        MCS_CONNECTED: "MCS_CONNECTED",
+        MCS_DISCONNECTED: "MCS_DISCONNECTED",
 
         // Media states'
         MEDIA_STATE: 'mediaState',

--- a/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
+++ b/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
@@ -242,19 +242,17 @@ module.exports = class Freeswitch extends EventEmitter {
           });
 
           session.on('rejected', (response, cause) => {
-            Logger.info("session rejected", response, cause);
+            Logger.info("[mcs-media-freeswitch] Session", elementId, "rejected", { cause })
+            this.emit(C.EVENT.MEDIA_DISCONNECTED+elementId);
           });
 
           session.on('failed', (response, cause) => {
-            Logger.info("session failed", response, cause);
-          });
-
-          session.on('progress', (response) => {
-            Logger.info("session progress", response);
+            Logger.info("[mcs-media-freeswitch] Session", elementId, "failed", { cause })
+            this.emit(C.EVENT.MEDIA_DISCONNECTED+elementId);
           });
 
           session.on('terminated', (response) => {
-            Logger.info("Session", elementId, "terminated")
+            Logger.info("[mcs-media-freeswitch] Session", elementId, "terminated")
             this.emit(C.EVENT.MEDIA_DISCONNECTED+elementId);
           });
 

--- a/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
+++ b/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
@@ -10,6 +10,7 @@ const Kurento = require('../kurento/kurento');
 const isError = require('../../utils/util').isError;
 const convertRange = require('../../utils/util').convertRange;
 const rid = require('readable-id');
+const { handleError } = require('../../utils/util');
 
 const FREESWITCH_IP = config.get('freeswitch').ip;
 const FREESWITCH_PORT = config.get('freeswitch').port;
@@ -192,12 +193,11 @@ module.exports = class Freeswitch extends EventEmitter {
     const userAgent = this._userAgents[elementId];
     const { voiceBridge } = userAgent;
     const { name, hackProxyViaKurento } = params
-    let mediaElement, host, proxyAnswer;
+    let mediaElement, host, proxyAnswer, isNegotiated = false;
 
     return new Promise(async (resolve, reject) => {
       try {
         if (userAgent) {
-
           if (sdpOffer == null || hackProxyViaKurento) {
             if (this._rtpConverters[elementId]) {
               mediaElement = this._rtpConverters[elementId].elementId;
@@ -231,12 +231,20 @@ module.exports = class Freeswitch extends EventEmitter {
 
           userAgent.session = session;
 
+          const handleNegotiationError = (c) => {
+            if (!isNegotiated) {
+              isNegotiated = true;
+              return reject(this._handleError(C.ERROR.MEDIA_PROCESS_OFFER_FAILED));
+            }
+          }
+
           session.on('accepted', (response, cause) => {
             if (response) {
               session.callId = response.call_id;
             }
 
             const answer = hackProxyViaKurento ? proxyAnswer : session.mediaHandler.remote_sdp;
+            isNegotiated = true;
 
             return resolve(answer);
           });
@@ -244,21 +252,22 @@ module.exports = class Freeswitch extends EventEmitter {
           session.on('rejected', (response, cause) => {
             Logger.info("[mcs-media-freeswitch] Session", elementId, "rejected", { cause })
             this.emit(C.EVENT.MEDIA_DISCONNECTED+elementId);
+            handleNegotiationError(cause);
           });
 
           session.on('failed', (response, cause) => {
             Logger.info("[mcs-media-freeswitch] Session", elementId, "failed", { cause })
             this.emit(C.EVENT.MEDIA_DISCONNECTED+elementId);
+            handleNegotiationError(cause);
           });
 
           session.on('terminated', (response) => {
             Logger.info("[mcs-media-freeswitch] Session", elementId, "terminated")
             this.emit(C.EVENT.MEDIA_DISCONNECTED+elementId);
+            handleNegotiationError();
           });
-
-
         } else {
-          return reject("[mcs-media] There is no element " + elementId);
+          return reject(C.ERROR.MEDIA_NOT_FOUND);
         }
       }
       catch (error) {
@@ -389,16 +398,9 @@ module.exports = class Freeswitch extends EventEmitter {
     return userAgent.invite(sipUri, options);
   }
 
-  _handleError(error) {
-    // Checking if the error needs to be wrapped into a JS Error instance
-    if (!isError(error)) {
-      error = new Error(error);
-    }
-
-    error.code = C.ERROR.MEDIA_SERVER_ERROR;
-    Logger.error('[mcs-media] Media Server returned error', error);
+  _handleError (error) {
+    return handleError('[mcs-media-freeswitch]', error);
   }
-
   sipjsLogConnector (level, category, label, content) {
     Logger.debug('[SIP.js]  ' + content);
   }

--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -9,7 +9,6 @@ const isError = require('../../utils/util').isError;
 const ERRORS = require('./errors.js');
 const KMS_CLIENT = require('kurento-client');
 const SdpWrapper = require('../../utils/sdp-wrapper');
-const Queue = require('kue');
 const GLOBAL_EVENT_EMITTER = require('../../utils/emitter');
 const SDPMedia = require('../../model/sdp-media');
 const RecordingMedia = require('../../model/recording-media');
@@ -25,34 +24,11 @@ module.exports = class Kurento extends EventEmitter {
       this._globalEmitter = GLOBAL_EVENT_EMITTER;
       this._mediaPipelines = {};
       this._mediaElements = {};
+      this._pipelinePromises = [];
       this._mediaServer;
       this._status;
       this._reconnectionRoutine = null;
       this._transposingQueue = [];
-      this._jobs = Queue.createQueue({
-        redis: {
-          port: config.get('redisPort'),
-          host: config.get('redisHost'),
-          //auth: 'password'
-        }
-      });
-      this._jobs.process('transposeAndConnect', async (job, done) => {
-        try {
-          await this._transposeAndConnect(job.data.sourceId, job.data.sinkId);
-          done();
-        } catch (e) {
-          done(e);
-        }
-      });
-      this._jobs.process('getMediaPipeline', async (job, done) => {
-        try {
-          await this._getMediaPipeline(job.data.hostId, job.data.roomId);
-          done();
-        } catch (e) {
-          done(e);
-        }
-      });
-
       this.balancer.on(C.EVENT.MEDIA_SERVER_OFFLINE, this._destroyElementsFromHost.bind(this));
       this._globalEmitter.on(C.EVENT.ROOM_EMPTY, this._releaseAllRoomPipelines.bind(this));
       instance = this;
@@ -70,37 +46,58 @@ module.exports = class Kurento extends EventEmitter {
         if (e) {
           return reject(e);
         }
+
+        p.host = host;
+        p.transposers = {};
+        p.activeElements = 0;
+
         return resolve(p);
       });
     });
   }
 
-  _getMediaPipeline (hostId, roomId) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const host = this.balancer.retrieveHost(hostId);
-        const { client } = host;
-        if (this._mediaPipelines[roomId] && this._mediaPipelines[roomId][host.id]) {
-          Logger.info(LOG_PREFIX, 'Pipeline for', roomId, 'at host', host.id, ' already exists.');
-          return resolve()
-        } else {
-          const pipeline = await this._createMediaPipeline(hostId);
-          pipeline.host = host;
-          pipeline.transposers = {};
-          if (this._mediaPipelines[roomId] == null) {
-            this._mediaPipelines[roomId] = {};
-          }
-          this._mediaPipelines[roomId][host.id] = pipeline;
-          Logger.info(LOG_PREFIX, "Created pipeline at room", roomId, "with host", hostId, host.id, pipeline.id);
-          pipeline.activeElements = 0;
+  async _getMediaPipeline (hostId, roomId) {
+    try {
+      const host = this.balancer.retrieveHost(hostId);
+      const { client } = host;
+      if (this._mediaPipelines[roomId] && this._mediaPipelines[roomId][host.id]) {
+        Logger.info(LOG_PREFIX, 'Pipeline for', roomId, 'at host', host.id, ' already exists.');
+        return this._mediaPipelines[roomId][host.id];
+      } else {
+        let pPromise;
 
-          return resolve();
+        const pPromiseObj = this._pipelinePromises.find(pp => pp.id === roomId + hostId);
+
+        if (pPromiseObj) {
+          ({ pPromise } = pPromiseObj);
         }
+
+        if (pPromise) {
+          return pPromise;
+        };
+
+        pPromise = this._createMediaPipeline(hostId);
+
+        this._pipelinePromises.push({ id: roomId + hostId, pPromise});
+
+        const pipeline = await pPromise;
+
+        if (this._mediaPipelines[roomId] == null) {
+          this._mediaPipelines[roomId] = {};
+        }
+
+        this._mediaPipelines[roomId][host.id] = pipeline;
+
+        this._pipelinePromises = this._pipelinePromises.filter(pp => pp.id !== roomId + hostId);
+
+        Logger.info(LOG_PREFIX, "Created pipeline at room", roomId, "with host", hostId, host.id, pipeline.id);
+
+        return pipeline;
       }
-      catch (err) {
-        return reject(this._handleError(err));
-      }
-    });
+    }
+    catch (err) {
+      throw (this._handleError(err));
+    }
   }
 
   _releaseAllRoomPipelines (room) {
@@ -248,25 +245,15 @@ module.exports = class Kurento extends EventEmitter {
     return new Promise(async (resolve, reject) => {
       try {
         const host = await this.balancer.getHost();
-        const job = await this._jobs.create('getMediaPipeline', {
-          hostId: host.id,
-          roomId
-        }).save().priority('high');
-
-        const onPipelineCreated = async (cjob) => {
-          const pipeline = this._mediaPipelines[roomId][host.id];
-          const mediaElement = await this._createElement(pipeline, type, options);
-          if (typeof mediaElement.setKeyframeInterval === 'function' && options.keyframeInterval) {
-            Logger.debug(LOG_PREFIX, "Creating element with keyframe interval set to", options.keyframeInterval);
-            mediaElement.setKeyframeInterval(options.keyframeInterval);
-          }
-          this._mediaPipelines[roomId][host.id].activeElements++;
-          return resolve({ mediaElement: mediaElement.id , host });
-        };
-
-        job.on('complete', onPipelineCreated).on('failed', (e) => {
-          return reject(e);
-        });
+        await this._getMediaPipeline(host.id, roomId);
+        const pipeline = this._mediaPipelines[roomId][host.id];
+        const mediaElement = await this._createElement(pipeline, type, options);
+        if (typeof mediaElement.setKeyframeInterval === 'function' && options.keyframeInterval) {
+          Logger.debug(LOG_PREFIX, "Creating element with keyframe interval set to", options.keyframeInterval);
+          mediaElement.setKeyframeInterval(options.keyframeInterval);
+        }
+        this._mediaPipelines[roomId][host.id].activeElements++;
+        return resolve({ mediaElement: mediaElement.id , host });
       }
       catch (err) {
         reject(this._handleError(err));
@@ -423,15 +410,8 @@ module.exports = class Kurento extends EventEmitter {
 
       try {
         if (shouldTranspose) {
-          const job = await this._jobs.create('transposeAndConnect', {
-            sourceId,
-            sinkId
-          }).save().priority('high');
-          job.on('complete', () => {
-            return resolve();
-          }).on('failed', (e) => {
-            return reject(e);
-          });
+          await this._transposeAndConnect(sourceId, sinkId);
+          return resolve();
         } else {
           await this._connect(source, sink, type);
           resolve();

--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -252,7 +252,23 @@ module.exports = class Kurento extends EventEmitter {
           Logger.debug(LOG_PREFIX, "Creating element with keyframe interval set to", options.keyframeInterval);
           mediaElement.setKeyframeInterval(options.keyframeInterval);
         }
+
+        // TODO make the rembParams and In/Out BW values fetch from the conference
+        // media specs
+        this.setOutputBandwidth(mediaElement, 300, 1500);
+        this.setInputBandwidth(mediaElement, 300, 1500);
+
+        const rembOptions = {
+          rembOnConnect: 500,
+          upLosses: 25,
+          decrementFactor: 0.85,
+          thresholdFactor: 0.9,
+        };
+        const rembParams = KMS_CLIENT.getComplexType('RembParams')(rembOptions);
+
+        mediaElement.setRembParams(rembParams);
         this._mediaPipelines[roomId][host.id].activeElements++;
+
         return resolve({ mediaElement: mediaElement.id , host });
       }
       catch (err) {
@@ -643,36 +659,29 @@ module.exports = class Kurento extends EventEmitter {
     });
   }
 
-  setInputBandwidth (elementId, min, max) {
-    let mediaElement = this._mediaElements[elementId];
-
-    if (mediaElement) {
-      mediaElement.setMinVideoRecvBandwidth(min);
-      mediaElement.setMaxVideoRecvBandwidth(max);
+  setInputBandwidth (element, min, max) {
+    if (element) {
+      element.setMinVideoRecvBandwidth(min);
+      element.setMaxVideoRecvBandwidth(max);
     } else {
-      return (LOG_PREFIX, "There is no element " + elementId);
+      throw (this._handleError(ERRORS[40101].error));
     }
   }
 
-  setOutputBandwidth (elementId, min, max) {
-    let mediaElement = this._mediaElements[elementId];
-
-    if (mediaElement) {
-      mediaElement.setMinVideoSendBandwidth(min);
-      mediaElement.setMaxVideoSendBandwidth(max);
+  setOutputBandwidth (element, min, max) {
+    if (element) {
+      element.setMinVideoSendBandwidth(min);
+      element.setMaxVideoSendBandwidth(max);
     } else {
-      return (LOG_PREFIX, "There is no element " + elementId );
+      throw (this._handleError(ERRORS[40101].error));
     }
   }
 
-  setOutputBitrate (elementId, min, max) {
-    let mediaElement = this._mediaElements[elementId];
-
-    if (mediaElement) {
-      mediaElement.setMinOutputBitrate(min);
-      mediaElement.setMaxOutputBitrate(max);
+  setOutputBitrate (element, bitrate) {
+    if (element) {
+      element.setOutputBitrate(bitrate);
     } else {
-      return (LOG_PREFIX, "There is no element " + elementId);
+      throw (this._handleError(ERRORS[40101].error));
     }
   }
 

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -7,6 +7,7 @@ const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
 const MediaController = require('./media-controller');
 const Logger = require('../utils/logger');
 const MCS = require('mcs-js');
+const LOG_PREFIX = "[mcs-router]"
 
 let instance = null;
 let clientId = 0;
@@ -26,6 +27,7 @@ const MR = class MCSRouter {
   }
 
   async start (address, port, secure) {
+    this._mediaController.start();
     this._dispatchEvents();
   }
 
@@ -321,8 +323,9 @@ const MR = class MCSRouter {
   }
 
   _handleError (error, operation) {
-    const { code, message, details } = error;
+    const { code, message, details, stack } = error;
     const response = { type: 'error', code, message, details, operation };
+    Logger.trace(LOG_PREFIX, "Error stack", stack);
     Logger.error("[mcs-router] Reject operation", response.operation, "with", { error: response });
 
     return response;

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -721,24 +721,22 @@ const MR = class MCSRouter {
       }
     });
 
-    this.emitter.on(C.EVENT.ROOM_CREATED, event => {
-      const { roomId } = event;
+    this.emitter.on(C.EVENT.ROOM_CREATED, roomId => {
       const clients = this._getClientToDispatch('all', C.EVENT.ROOM_CREATED);
 
-      Logger.trace('[mcs-router] Room created event', event, typeof client);
+      Logger.trace('[mcs-router] Room created event', roomId, typeof client);
 
       if (clients.length > 0) {
         clients.forEach(client => {
-          client.roomCreated(event);
+          client.roomCreated(roomId);
         })
       }
     });
 
-    this.emitter.on(C.EVENT.ROOM_DESTROYED, event => {
-      const { roomId } = event;
-      const clients = this._getClientToDispatch('all', C.EVENT.ROOM_DESTROYED);
+    this.emitter.on(C.EVENT.ROOM_DESTROYED, roomId => {
+      const clients = this._getClientToDispatch(roomId, C.EVENT.ROOM_DESTROYED);
 
-      Logger.trace('[mcs-router] Room destroyed event', event, typeof client);
+      Logger.trace('[mcs-router] Room destroyed event', roomId, typeof client);
 
       this._removeFromClientEventMap(roomId, C.EVENT.MEDIA_CONNECTED);
       this._removeFromClientEventMap(roomId, C.EVENT.USER_JOINED);
@@ -746,7 +744,7 @@ const MR = class MCSRouter {
 
       if (clients.length > 0) {
         clients.forEach(client => {
-          client.roomDestroyed(event);
+          client.roomDestroyed(roomId);
         })
       }
     });

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -573,7 +573,7 @@ const MR = class MCSRouter {
       try {
         ({ transactionId, mediaId, roomId } = args);
         const { floor, previousFloor } = await this.setContentFloor(args)
-        client.contentFloorChanged(roomId, { floor, previousFloor, transactionId })
+        client.contentFloor(roomId, { floor, previousFloor, transactionId })
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -691,7 +691,7 @@ const MR = class MCSRouter {
     const clientMap = this.clientEventMap.filter(c => c.identifier === identifier && c.eventName === eventName);
 
     if (clientMap.length > 0 ) {
-      Logger.trace('[mcs-router] Found clients', clientMap.map(c => [c.identifier, c.eventName, c.client.trackingId]))
+      Logger.trace('[mcs-router] Found', clientMap.length, 'clients', clientMap.map(c => [c.identifier, c.eventName, c.client.trackingId]))
     }
 
     const clients = clientMap.map(cm => cm.client);

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -227,8 +227,8 @@ const MR = class MCSRouter {
   async setConferenceFloor(args) {
     try {
       const { mediaId, roomId } = args
-      const mediaInfo = await this._mediaController.setConferenceFloor(roomId, mediaId)
-      return mediaInfo;
+      const floorInfo = await this._mediaController.setConferenceFloor(roomId, mediaId)
+      return floorInfo;
     }
     catch (error) {
       throw (this._handleError(error, 'setConferenceFloor', {}))
@@ -238,8 +238,8 @@ const MR = class MCSRouter {
   async setContentFloor(args) {
     try {
       const { roomId, mediaId } = args
-      const mediaInfo = await this._mediaController.setContentFloor(roomId, mediaId)
-      return mediaInfo;
+      const floorInfo = await this._mediaController.setContentFloor(roomId, mediaId)
+      return floorInfo;
     }
     catch (error) {
       throw (this._handleError(error, 'setContentFloor', {}))
@@ -248,8 +248,9 @@ const MR = class MCSRouter {
 
   async releaseConferenceFloor(args) {
     try {
-      const { mediaId, roomId } = args
-      await this._mediaController.releaseConferenceFloor(roomId, mediaId)
+      const { roomId } = args
+      const previousFloor = await this._mediaController.releaseConferenceFloor(roomId)
+      return previousFloor;
     }
     catch (error) {
       throw (this._handleError(error, 'releaseConferenceFloor', {}))
@@ -258,8 +259,9 @@ const MR = class MCSRouter {
 
   async releaseContentFloor(args) {
     try {
-      const { roomId, mediaId } = args
-      await this._mediaController.releaseContentFloor(roomId, mediaId)
+      const { roomId } = args
+      const previousFloor = await this._mediaController.releaseContentFloor(roomId)
+      return previousFloor;
     }
     catch (error) {
       throw (this._handleError(error, 'releaseContentFloor', {}))
@@ -269,8 +271,8 @@ const MR = class MCSRouter {
   async getConferenceFloor(args) {
     const { roomId } = args
     try {
-      const mediaId = await this._mediaController.getConferenceFloor(roomId)
-      return mediaId;
+      const floorInfo = await this._mediaController.getConferenceFloor(roomId)
+      return floorInfo;
     }
     catch (error) {
       throw (this._handleError(error, 'getConferenceFloor', {}))
@@ -280,8 +282,8 @@ const MR = class MCSRouter {
   async getContentFloor(args) {
     const { roomId } = args
     try {
-      const mediaId = await this._mediaController.getContentFloor(roomId)
-      return mediaId;
+      const floorInfo = await this._mediaController.getContentFloor(roomId)
+      return floorInfo;
     }
     catch (error) {
       throw (this._handleError(error, 'getContentFloor', {}))
@@ -558,8 +560,8 @@ const MR = class MCSRouter {
       let transactionId, mediaId, roomId;
       try {
         ({transactionId, mediaId, roomId } = args);
-        const media = await this.setConferenceFloor(args)
-        client.conferenceFloorChanged(roomId, media, {transactionId})
+        const { floor, previousFloor } = await this.setConferenceFloor(args)
+        client.conferenceFloorChanged(roomId, { floor, previousFloor, transactionId })
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -570,8 +572,8 @@ const MR = class MCSRouter {
       let transactionId, mediaId, roomId;
       try {
         ({ transactionId, mediaId, roomId } = args);
-        const media = await this.setContentFloor(args)
-        client.contentFloorChanged(roomId, media, {transactionId})
+        const { floor, previousFloor } = await this.setContentFloor(args)
+        client.contentFloorChanged(roomId, { floor, previousFloor, transactionId })
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -579,11 +581,11 @@ const MR = class MCSRouter {
     });
 
     client.on('releaseConferenceFloor', async (args) => {
-      let transactionId, mediaId, roomId;
+      let transactionId, roomId;
       try {
-        ({ transactionId, mediaId, roomId} = args);
-        const media = await this.releaseConferenceFloor(args)
-        client.conferenceFloorChanged(roomId, {}, {transactionId})
+        ({ transactionId, roomId} = args);
+        const previousFloor = await this.releaseConferenceFloor(args)
+        client.conferenceFloorChanged(roomId, { previousFloor, transactionId })
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -591,11 +593,11 @@ const MR = class MCSRouter {
     });
 
     client.on('releaseContentFloor', async (args) =>{
-      let transactionId, mediaId, roomId;
+      let transactionId, roomId;
       try {
-        ({ transactionId, mediaId, roomId} = args);
-        await this.releaseContentFloor(args)
-        client.contentFloorChanged(roomId, {}, {transactionId})
+        ({ transactionId, roomId} = args);
+        const previousFloor = await this.releaseContentFloor(args)
+        client.contentFloorChanged(roomId, { previousFloor, transactionId })
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -606,8 +608,8 @@ const MR = class MCSRouter {
       let transactionId, roomId;
       try {
         ({ transactionId, roomId } = args);
-        const mediaId = await this.getContentFloor(args)
-        client.contentFloor(roomId, mediaId, {transactionId})
+        const { floor, previousFloor }  = await this.getContentFloor(args)
+        client.contentFloor(roomId, { floor, previousFloor, transactionId })
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -618,8 +620,8 @@ const MR = class MCSRouter {
       let transactionId, roomId;
       try {
         ({ transactionId, roomId } = args);
-        const mediaId = await this.getConferenceFloor(args)
-        client.conferenceFloor(roomId, mediaId, {transactionId})
+        const { floor, previousFloor } = await this.getConferenceFloor(args)
+        client.conferenceFloor(roomId, { floor, previousFloor, transactionId})
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)
@@ -799,23 +801,23 @@ const MR = class MCSRouter {
     });
 
     this.emitter.on(C.EVENT.CONTENT_FLOOR_CHANGED, event => {
-      const { roomId, media } = event;
+      const { roomId, floor, previousFloor } = event;
       const clients = this._getClientToDispatch(roomId, C.EVENT.CONTENT_FLOOR_CHANGED);
 
       if (clients.length > 0) {
         clients.forEach(client => {
-          client.contentFloorChanged(roomId, media);
+          client.contentFloorChanged(roomId, { floor, previousFloor });
         })
       }
     });
 
     this.emitter.on(C.EVENT.CONFERENCE_FLOOR_CHANGED, event => {
-      const { roomId, media } = event;
+      const { roomId, floor, previousFloor } = event;
       const clients = this._getClientToDispatch(roomId, C.EVENT.CONFERENCE_FLOOR_CHANGED);
 
       if (clients.length > 0) {
         clients.forEach(client => {
-          client.conferenceFloorChanged(roomId, media);
+          client.conferenceFloorChanged(roomId, { floor, previousFloor });
         })
       }
     });

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -503,7 +503,6 @@ module.exports = class MediaController {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        // TODO dinamically understand if we're talking about a media unit or session
         const media = this.getMediaSession(mediaId);
         Logger.info('[mcs-controller] Fetched room', room.id, 'and media', media.id);
         const mediaInfo = room.setContentFloor(media);

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -508,7 +508,6 @@ module.exports = class MediaController {
       try {
         const room = await this.getRoom(roomId);
         const media = this.getMediaSession(mediaId);
-        Logger.info(LOG_PREFIX, 'Fetched room', room.id, 'and media', media.id);
         const mediaInfo = room.setContentFloor(media);
         resolve(mediaInfo);
       }
@@ -523,7 +522,6 @@ module.exports = class MediaController {
       try {
         const room = await this.getRoom(roomId);
         const media = this.getMediaSession(mediaId);
-        Logger.info(LOG_PREFIX, 'Fetched room', room.id, 'and media', media.id);
         const mediaInfo = room.setConferenceFloor(media);
         resolve(mediaInfo);
       }
@@ -533,12 +531,11 @@ module.exports = class MediaController {
     })
   }
 
-  releaseContentFloor(roomId, mediaId) {
+  releaseContentFloor(roomId) {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        Logger.info(LOG_PREFIX, 'Fetched room', room.id);
-        room.releaseContentFloor(mediaId);
+        room.releaseContentFloor();
         resolve();
       }
       catch (error) {
@@ -547,12 +544,11 @@ module.exports = class MediaController {
     })
   }
 
-  releaseConferenceFloor(roomId, mediaId) {
+  releaseConferenceFloor(roomId) {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        Logger.info(LOG_PREFIX, 'Fetched room', room.id);
-        room.releaseConferenceFloor(mediaId);
+        room.releaseConferenceFloor();
         resolve();
       }
       catch (error) {
@@ -565,7 +561,6 @@ module.exports = class MediaController {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        Logger.info(LOG_PREFIX, 'Fetched room', room.id);
         resolve(room.getContentFloor());
       }
       catch (error) {

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -72,7 +72,7 @@ module.exports = class MediaController {
   }
 
   async leave (roomId, userId) {
-    Logger.info(LOG_PREFIX, "User => " + userId + " wants to leave ");
+    Logger.info(LOG_PREFIX, "User", userId, "wants to leave.");
     let user, room;
 
     try {
@@ -88,7 +88,12 @@ module.exports = class MediaController {
       const killedMedias = await user.leave();
 
       killedMedias.forEach((mediaId) => {
-        this.removeMediaSession(mediaId);
+        try {
+          this.removeMediaSession(mediaId);
+        } catch (e) {
+          // Media was probably not found, just log it here and go on
+          this._handleError(e);
+        }
       });
 
       room.destroyUser(user.id);

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -29,9 +29,10 @@ module.exports = class MediaController {
     return instance;
   }
 
-  start (_kurentoClient, _kurentoToken, callback) {
-    // TODO
-    return callback(null);
+  start () {
+    GLOBAL_EVENT_EMITTER.on(C.EVENT.ROOM_EMPTY, (roomId) => {
+      this.removeRoom(roomId);
+    });
   }
 
   stop () {
@@ -55,14 +56,14 @@ module.exports = class MediaController {
   }
 
   async join (roomId, type, params) {
-    Logger.info("[mcs-controller] Join room => " + roomId + ' as ' + type);
+    Logger.info(LOG_PREFIX, "Join room => " + roomId + ' as ' + type);
     try {
       let session;
       const room = await this.createRoom(roomId);
       const user = this.createUser(roomId, type, params);
       room.setUser(user);
 
-      Logger.info("[mcs-controller] Resolving user " + user.id);
+      Logger.info(LOG_PREFIX, "Resolving user " + user.id);
       return Promise.resolve(user.id);
     }
     catch (err) {
@@ -71,7 +72,7 @@ module.exports = class MediaController {
   }
 
   async leave (roomId, userId) {
-    Logger.info("[mcs-controller] User => " + userId + " wants to leave ");
+    Logger.info(LOG_PREFIX, "User => " + userId + " wants to leave ");
     let user, room;
 
     try {
@@ -79,7 +80,7 @@ module.exports = class MediaController {
       user = this.getUser(userId);
     } catch (err) {
       // User or room were already closed or not found, resolving as it is
-      Logger.warn('[mcs-controller] Leave for', userId, 'at', roomId, 'failed with error', this._handleError(err));
+      Logger.warn(LOG_PREFIX, 'Leave for', userId, 'at', roomId, 'failed with error', this._handleError(err));
       return Promise.resolve(err);
     }
 
@@ -93,8 +94,8 @@ module.exports = class MediaController {
       room.destroyUser(user.id);
       this.removeUser(user.id);
 
-      Logger.trace('[mcs-controller] Active media sessions', this.mediaSessions.map(ms => ms.id));
-      Logger.trace("[mcs-controller] Active users", this.users.map(u => u.id));
+      Logger.trace(LOG_PREFIX, 'Active media sessions', this.mediaSessions.map(ms => ms.id));
+      Logger.trace(LOG_PREFIX, "Active users", this.users.map(u => u.id));
 
       return Promise.resolve();
     }
@@ -105,7 +106,7 @@ module.exports = class MediaController {
 
   publishAndSubscribe (roomId, userId, sourceId, type, params = {}) {
     return new Promise(async (resolve, reject) => {
-      Logger.info("[mcs-controller] PublishAndSubscribe from user", userId, "to source", sourceId);
+      Logger.info(LOG_PREFIX, "PublishAndSubscribe from user", userId, "to source", sourceId);
       Logger.trace("[mcs-controler] PublishAndSubscribe descriptor is", params.descriptor);
 
       try {
@@ -115,7 +116,7 @@ module.exports = class MediaController {
           source = this.mediaSessions[0];
         }
 
-        Logger.info("[mcs-controller] Fetched user", user.id);
+        Logger.info(LOG_PREFIX, "Fetched user", user.id);
 
         type = C.EMAP[type];
 
@@ -145,13 +146,13 @@ module.exports = class MediaController {
 
   publish (userId, roomId, type, params = {}) {
     return new Promise(async (resolve, reject) => {
-      Logger.info("[mcs-controller] Publish from user", userId, "to room", roomId);
+      Logger.info(LOG_PREFIX, "Publish from user", userId, "to room", roomId);
       Logger.trace("[mcs-controler] Publish descriptor is", params.descriptor);
 
       try {
         const user = await this.getUser(userId);
 
-        Logger.info("[mcs-controller] Fetched user", user.id);
+        Logger.info(LOG_PREFIX, "Fetched user", user.id);
 
         type = C.EMAP[type];
 
@@ -177,7 +178,7 @@ module.exports = class MediaController {
 
   subscribe (userId, sourceId, type, params = {}) {
     return new Promise(async (resolve, reject) => {
-      Logger.info("[mcs-controller] Subscribe from user", userId, "to source", sourceId);
+      Logger.info(LOG_PREFIX, "Subscribe from user", userId, "to source", sourceId);
       Logger.trace("[mcs-controler] Subscribe descriptor is", params.descriptor);
 
       try {
@@ -191,7 +192,7 @@ module.exports = class MediaController {
           source = this.getMediaSession(sourceId);
         }
 
-        Logger.info("[mcs-controller] Fetched user", user.id);
+        Logger.info(LOG_PREFIX, "Fetched user", user.id);
 
         type = C.EMAP[type];
 
@@ -204,7 +205,7 @@ module.exports = class MediaController {
             //source.subscribedSessions.push(session.id);
             resolve({descriptor: answer, mediaId: session.id});
             session.sessionStarted();
-            Logger.trace("[mcs-controller] Updated", source.id,  "subscribers list to", source.subscribedSessions);
+            Logger.trace(LOG_PREFIX, "Updated", source.id,  "subscribers list to", source.subscribedSessions);
             break;
           default:
             return reject(this._handleError(C.ERROR.MEDIA_INVALID_TYPE));
@@ -221,7 +222,7 @@ module.exports = class MediaController {
       const user = this.getUser(userId);
       const answer = await user.unpublish(mediaId);
       this.removeMediaSession(mediaId);
-      Logger.trace('[mcs-controller] Active media sessions', this.mediaSessions.map(ms => ms.id));
+      Logger.trace(LOG_PREFIX, 'Active media sessions', this.mediaSessions.map(ms => ms.id));
       return Promise.resolve(answer);
     }
     catch (err) {
@@ -236,7 +237,7 @@ module.exports = class MediaController {
       const media = this.getMediaSession(mediaId);
       const answer = await user.unsubscribe(mediaId);
       this.removeMediaSession(mediaId);
-      Logger.trace('[mcs-controller] Active media sessions', this.mediaSessions.map(ms => ms.id));
+      Logger.trace(LOG_PREFIX, 'Active media sessions', this.mediaSessions.map(ms => ms.id));
       return Promise.resolve();
     }
     catch (err) {
@@ -247,7 +248,7 @@ module.exports = class MediaController {
   startRecording (userId, sourceId, recordingPath, params) {
     return new Promise(async (resolve, reject) => {
       try {
-        Logger.info("[mcs-controller] startRecording ", sourceId);
+        Logger.info(LOG_PREFIX, "startRecording ", sourceId);
         const user = await this.getUser(userId);
         const sourceSession = this.getMediaSession(sourceId);
 
@@ -267,7 +268,7 @@ module.exports = class MediaController {
 
   async stopRecording (userId, recId) {
     return new Promise(async (resolve, reject) => {
-      Logger.info("[mcs-controller] Stopping recording session", recId);
+      Logger.info(LOG_PREFIX, "Stopping recording session", recId);
       try {
         const user = await this.getUser(userId);
         const recSession = this.getMediaSession(recId);
@@ -285,7 +286,7 @@ module.exports = class MediaController {
 
   connect (sourceId, sinkId, type = 'ALL') {
     return new Promise(async (resolve, reject) => {
-      Logger.info("[mcs-controller] Connect", sourceId, "to", sinkId, "with type", type);
+      Logger.info(LOG_PREFIX, "Connect", sourceId, "to", sinkId, "with type", type);
 
       try {
         const sourceSession = this.getMediaSession(sourceId);
@@ -303,7 +304,7 @@ module.exports = class MediaController {
   disconnect (sourceId, sinkId, type = 'ALL') {
     return new Promise(async (resolve, reject) => {
       try {
-        Logger.info("[mcs-controller] Disconnect", sourceId, "from", sinkId, "with type", type);
+        Logger.info(LOG_PREFIX, "Disconnect", sourceId, "from", sinkId, "with type", type);
         const sourceSession = this.getMediaSession(sourceId);
         const sinkSession = this.getMediaSession(sinkId);
 
@@ -352,7 +353,7 @@ module.exports = class MediaController {
         case C.EVENT.CONFERENCE_FLOOR_CHANGED:
           // TODO refactor
           break;
-        default: Logger.trace("[mcs-controller] Invalid event subscription", mappedEvent, identifier);
+        default: Logger.trace(LOG_PREFIX, "Invalid event subscription", mappedEvent, identifier);
       }
     }
     catch (err) {
@@ -365,7 +366,7 @@ module.exports = class MediaController {
    * @param {String} roomId
    */
   async createRoom (roomId)  {
-    Logger.info("[mcs-controller] Creating new room with ID", roomId);
+    Logger.info(LOG_PREFIX, "Creating new room with ID", roomId);
 
     let room = this.rooms.find(r => r.id === roomId);
 
@@ -383,7 +384,7 @@ module.exports = class MediaController {
    * @param {String} roomId
    */
   createUser (roomId, type, params)  {
-    Logger.info("[mcs-controller] Creating a new", type, "user at room", roomId);
+    Logger.info(LOG_PREFIX, "Creating a new", type, "user at room", roomId);
 
     const user = new User(roomId, type, params);
     this.users.push(user);
@@ -421,6 +422,9 @@ module.exports = class MediaController {
         return true;
       }
 
+      Logger.debug(LOG_PREFIX, "Removing room", roomId);
+
+      r.destroy();
       this.emitter.emit(C.EVENT.ROOM_DESTROYED, r.id);
       return false;
     });
@@ -504,7 +508,7 @@ module.exports = class MediaController {
       try {
         const room = await this.getRoom(roomId);
         const media = this.getMediaSession(mediaId);
-        Logger.info('[mcs-controller] Fetched room', room.id, 'and media', media.id);
+        Logger.info(LOG_PREFIX, 'Fetched room', room.id, 'and media', media.id);
         const mediaInfo = room.setContentFloor(media);
         resolve(mediaInfo);
       }
@@ -519,7 +523,7 @@ module.exports = class MediaController {
       try {
         const room = await this.getRoom(roomId);
         const media = this.getMediaSession(mediaId);
-        Logger.info('[mcs-controller] Fetched room', room.id, 'and media', media.id);
+        Logger.info(LOG_PREFIX, 'Fetched room', room.id, 'and media', media.id);
         const mediaInfo = room.setConferenceFloor(media);
         resolve(mediaInfo);
       }
@@ -533,7 +537,7 @@ module.exports = class MediaController {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        Logger.info('[mcs-controller] Fetched room', room.id);
+        Logger.info(LOG_PREFIX, 'Fetched room', room.id);
         room.releaseContentFloor(mediaId);
         resolve();
       }
@@ -547,7 +551,7 @@ module.exports = class MediaController {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        Logger.info('[mcs-controller] Fetched room', room.id);
+        Logger.info(LOG_PREFIX, 'Fetched room', room.id);
         room.releaseConferenceFloor(mediaId);
         resolve();
       }
@@ -561,7 +565,7 @@ module.exports = class MediaController {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        Logger.info('[mcs-controller] Fetched room', room.id);
+        Logger.info(LOG_PREFIX, 'Fetched room', room.id);
         resolve(room.getContentFloor());
       }
       catch (error) {
@@ -574,7 +578,7 @@ module.exports = class MediaController {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        Logger.info('[mcs-controller] Fetched room', room.id);
+        Logger.info(LOG_PREFIX, 'Fetched room', room.id);
         resolve(room.getConferenceFloor());
       }
       catch (error) {

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -62,6 +62,7 @@ module.exports = class MediaSession {
       video: false,
       audio: false,
       text: false,
+      content: false,
       application: false,
       message: false,
     }
@@ -88,6 +89,9 @@ module.exports = class MediaSession {
         });
 
         this._status = C.STATUS.STOPPED;
+
+        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.id, mediaSessionId: this.mediaSessionId });
+
         return Promise.resolve();
       }
       catch (err) {
@@ -307,11 +311,11 @@ module.exports = class MediaSession {
     });
   }
 
-  getApplicationMedia () {
-    let applicationMedia = this.medias.find(m => m.mediaTypes.application && m.mediaTypes.application !== 'recvonly')
+  getContentMedia () {
+    let contentMedia = this.medias.find(m => m.mediaTypes.content && m.mediaTypes.content !== 'recvonly')
 
-    if (applicationMedia) {
-      return applicationMedia;
+    if (contentMedia) {
+      return contentMedia;
     }
 
     return this.medias.find(m => m.mediaTypes.video && m.mediaTypes.video !== 'recvonly');

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -299,11 +299,21 @@ module.exports = class MediaSession {
     return handleError(LOG_PREFIX, error);
   }
 
-  createAndSetMediaNames() {
+  createAndSetMediaNames () {
     this.medias.forEach(async (m, index) => {
       let name = `${this.name}-${++index}`
       Logger.debug(LOG_PREFIX,"Setting name", name, "for media", m.id);
       m.setName(name);
     });
+  }
+
+  getApplicationMedia () {
+    let applicationMedia = this.medias.find(m => m.mediaTypes.application && m.mediaTypes.application !== 'recvonly')
+
+    if (applicationMedia) {
+      return applicationMedia;
+    }
+
+    return this.medias.find(m => m.mediaTypes.video && m.mediaTypes.video !== 'recvonly');
   }
 }

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -106,16 +106,16 @@ module.exports = class MediaSession {
   async connect (sink, type = 'ALL') {
     try {
       // Connect this media session to sinks of the appropriate type
-      // in the future, it'd also be nice to be able to connect children media of a session
+      // TODO REVIEW THE CONTENT X VIDEO CONNECTION_TYPE ASAP (it makes little sense)
       switch (type ) {
-        case C.CONNECTION_TYPE.CONTENT:
-          await this._connectContent(sink);
-          break;
         case C.CONNECTION_TYPE.AUDIO:
           await this._connectAudio(sink);
           break;
         case C.CONNECTION_TYPE.VIDEO:
           await this._connectVideo(sink);
+          break;
+        case C.CONNECTION_TYPE.CONTENT:
+          await this._connectContent(sink);
           break;
         default:
           await this._connectEverything(sink);

--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -138,17 +138,17 @@ module.exports = class Media {
 
   async connect (sink, type = 'ALL') {
     try {
-      // Connect this media session to sinks of the appropriate type
-      // in the future, it'd also be nice to be able to connect children media of a session
+      // Connect this media unit to sinks of the appropriate type
+      // TODO REVIEW THE CONTENT X VIDEO CONNECTION_TYPE ASAP (it makes little sense)
       switch (type ) {
-        case C.CONNECTION_TYPE.CONTENT:
-          await this._connectContent(sink);
-          break;
         case C.CONNECTION_TYPE.AUDIO:
           await this._connectAudio(sink);
           break;
         case C.CONNECTION_TYPE.VIDEO:
           await this._connectVideo(sink);
+          break;
+        case C.CONNECTION_TYPE.CONTENT:
+          await this._connectContent(sink);
           break;
         default:
           await this._connectEverything(sink);

--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -43,6 +43,7 @@ module.exports = class Media {
       video: false,
       audio: false,
       text: false,
+      content: false,
       application: false,
       message: false,
     }
@@ -103,7 +104,6 @@ module.exports = class Media {
 
     this.adapter.once(C.EVENT.MEDIA_DISCONNECTED+this.adapterElementId, this.stop.bind(this));
 
-
     Logger.info(LOG_PREFIX, "New media session", this.id, "in room", this.roomId, "started with media server endpoint", this.adapterElementId);
   }
 
@@ -123,7 +123,7 @@ module.exports = class Media {
 
         this.status = C.STATUS.STOPPED;
         Logger.info(LOG_PREFIX, "Session", this.id, "stopped with status", this.status);
-        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.mediaSessionId, mediaSessionId: this.mediaSessionId });
+        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.id, mediaSessionId: this.mediaSessionId });
 
         return Promise.resolve();
       }
@@ -320,6 +320,7 @@ module.exports = class Media {
 
   getMediaInfo () {
     const mediaInfo = {
+      mediaSessionId: this.mediaSessionId,
       mediaId: this.id,
       roomId: this.roomId,
       userId: this.userId,
@@ -372,7 +373,7 @@ module.exports = class Media {
     return this._subscribedTo;
   }
 
-  getApplicationMedia () {
+  getContentMedia () {
     return this;
   }
 

--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -372,6 +372,10 @@ module.exports = class Media {
     return this._subscribedTo;
   }
 
+  getApplicationMedia () {
+    return this;
+  }
+
   _handleError (error) {
     this._status = C.STATUS.STOPPED;
     return handleError(LOG_PREFIX, error);

--- a/lib/mcs-core/lib/model/room.js
+++ b/lib/mcs-core/lib/model/room.js
@@ -46,7 +46,7 @@ module.exports = class Room {
   }
 
   setContentFloor(media) {
-    this._contentFloor = media;
+    this._contentFloor = media.getApplicationMedia();
     const mediaInfo = this._contentFloor.getMediaInfo();
     this._emitter.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, media: mediaInfo});
     return mediaInfo;
@@ -60,10 +60,8 @@ module.exports = class Room {
   }
 
   releaseContentFloor(mediaId) {
-    if (this._contentFloor.id === mediaId) {
-      this._contentFloor = null
-      this._emitter.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, media: {}}) ;
-    }
+    this._contentFloor = null
+    this._emitter.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, media: {}}) ;
   }
 
   destroyUser(userId) {

--- a/lib/mcs-core/lib/model/room.js
+++ b/lib/mcs-core/lib/model/room.js
@@ -15,7 +15,9 @@ module.exports = class Room {
     this.id = id;
     this._users = {};
     this._conferenceFloor;
+    this._previousConferenceFloors = [];
     this._contentFloor;
+    this._previousContentFloors = [];
     this._registeredEvents = [];
     this._trackContentMediaDisconnection();
     this._trackConferenceMediaDisconnection();
@@ -29,45 +31,81 @@ module.exports = class Room {
     return Object.keys(this._users).map(uk => this._users[uk].getUserInfo());
   }
 
-  getConferenceFloor () {
-    return this._conferenceFloor? this._conferenceFloor.id : null;
-  }
-
-  getContentFloor () {
-    return this._contentFloor? this._contentFloor.id : null;
-  }
-
   setUser (user) {
     this._users[user.id] = user;
     GLOBAL_EVENT_EMITTER.emit(C.EVENT.USER_JOINED, { roomId: this.id, user: user.getUserInfo() });
   }
 
+  getConferenceFloor () {
+    const conferenceFloorInfo = {
+      floor: this._conferenceFloor? this._conferenceFloor.getMediaInfo() : undefined,
+      previousFloor: this._previousConferenceFloors[0]? this._previousConferenceFloors[0].getMediaInfo() : undefined,
+    };
+
+    return conferenceFloorInfo;
+  }
+
+  getContentFloor () {
+    const contentFloorInfo = {
+      floor: this._contentFloor? this._contentFloor.getMediaInfo() : undefined,
+      previousFloor: this._previousContentFloors[0]? this._previousContentFloors[0].getMediaInfo() : undefined,
+    };
+
+    return contentFloorInfo;
+  }
+
+  _setPreviousConferenceFloor () {
+    this._previousConferenceFloors = this._previousConferenceFloors.filter(pcf => pcf.id !== this._conferenceFloor.id);
+    this._previousConferenceFloors.unshift(this._conferenceFloor);
+  }
+
   setConferenceFloor (media) {
+    if (this._conferenceFloor && this._previousConferenceFloor[0] && this._previousConferenceFloor[0].id !== this._conferenceFloor.id) {
+      this._setPreviousConferenceFloor();
+    }
+
     this._conferenceFloor = media;
-    const mediaInfo = media.getMediaInfo();
-    GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, media: mediaInfo});
-    return mediaInfo;
+    const conferenceFloorInfo = this.getConferenceFloor();
+    GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, ...conferenceFloorInfo });
+    return conferenceFloorInfo;
+  }
+
+  _setPreviousContentFloor () {
+    this._previousContentFloors = this._previousContentFloors.filter(pcf => pcf.id !== this._contentFloor.id);
+    this._previousContentFloors.unshift(this._contentFloor);
   }
 
   setContentFloor (media) {
-    this._contentFloor = media.getApplicationMedia();
-    const mediaInfo = this._contentFloor.getMediaInfo();
-    GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, media: mediaInfo});
-    return mediaInfo;
+    if (this._contentFloor && this._previousContentFloors[0] && this._previousContentFloors[0].id !== this._contentFloor.id) {
+      this._setPreviousContentFloor();
+    }
+
+    this._contentFloor = media.getContentMedia();
+    const contentFloorInfo = this.getContentFloor();
+    GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, ...contentFloorInfo });
+    return contentFloorInfo;
   }
 
   releaseConferenceFloor () {
-    if (this.getConferenceFloor()) {
+    if (this._conferenceFloor) {
+      this._setPreviousConferenceFloor();
       this._conferenceFloor = null
-      GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, media: {}});
+      const conferenceFloorInfo = this.getConferenceFloor();
+      GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, ...conferenceFloorInfo});
     }
+
+    return this._previousConferenceFloors[0];
   }
 
   releaseContentFloor () {
-    if (this.getContentFloor()) {
+    if (this._contentFloor) {
+      this._setPreviousContentFloor();
       this._contentFloor = null;
-      GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, media: {}}) ;
+      const contentFloorInfo = this.getContentFloor();
+      GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, ...contentFloorInfo }) ;
     }
+
+    return this._previousContentFloors[0];
   }
 
   _registerEvent (event, callback) {
@@ -79,10 +117,14 @@ module.exports = class Room {
     // Used when devices ungracefully disconnect from the system
     const clearContentFloor = (event) => {
       const { mediaId, roomId, mediaSessionId } = event;
-      const contentFloorId = this.getContentFloor();
+      if (roomId === this.id) {
+        const contentFloorId = this.getContentFloor();
 
-      if (roomId === this.id && (mediaId === contentFloorId || mediaSessionId === contentFloorId)) {
-        this.releaseContentFloor(contentFloorId);
+        if (mediaId === contentFloorId || mediaSessionId === contentFloorId) {
+          this.releaseContentFloor(contentFloorId);
+        }
+
+        this._previousContentFloors = this._previousContentFloors.filter(pcf => pcf.id !== mediaId);
       }
     };
 
@@ -95,10 +137,14 @@ module.exports = class Room {
     // Used when devices ungracefully disconnect from the system
     const clearConferenceFloor = (event) => {
       const { mediaId, roomId, mediaSessionId } = event;
-      const conferenceFloorId = this.getConferenceFloor();
+      if (roomId === this.id) {
+        const conferenceFloorId = this.getConferenceFloor();
 
-      if (roomId === this.id && (mediaId === conferenceFloorId || mediaSessionId === conferenceFloorId)) {
-        this.releaseConferenceFloor(conferenceFloorId);
+        if (roomId === this.id && (mediaId === conferenceFloorId || mediaSessionId === conferenceFloorId)) {
+          this.releaseConferenceFloor(conferenceFloorId);
+        }
+
+        this._previousConferenceFloors = this._previousConferenceFloors.filter(pcf => pcf.id !== mediaId);
       }
     };
 

--- a/lib/mcs-core/lib/model/room.js
+++ b/lib/mcs-core/lib/model/room.js
@@ -118,10 +118,9 @@ module.exports = class Room {
     const clearContentFloor = (event) => {
       const { mediaId, roomId, mediaSessionId } = event;
       if (roomId === this.id) {
-        const contentFloorId = this.getContentFloor();
-
-        if (mediaId === contentFloorId || mediaSessionId === contentFloorId) {
-          this.releaseContentFloor(contentFloorId);
+        const { floor } = this.getContentFloor();
+        if (floor && (mediaId === floor.mediaId || mediaSessionId === floor.mediaId)) {
+          this.releaseContentFloor();
         }
 
         this._previousContentFloors = this._previousContentFloors.filter(pcf => pcf.id !== mediaId);
@@ -138,10 +137,10 @@ module.exports = class Room {
     const clearConferenceFloor = (event) => {
       const { mediaId, roomId, mediaSessionId } = event;
       if (roomId === this.id) {
-        const conferenceFloorId = this.getConferenceFloor();
+        const { floor } = this.getContentFloor();
 
-        if (roomId === this.id && (mediaId === conferenceFloorId || mediaSessionId === conferenceFloorId)) {
-          this.releaseConferenceFloor(conferenceFloorId);
+        if (floor && (mediaId === floor.mediaId || mediaSessionId === floor.mediaId)) {
+          this.releaseConferenceFloor();
         }
 
         this._previousConferenceFloors = this._previousConferenceFloors.filter(pcf => pcf.id !== mediaId);

--- a/lib/mcs-core/lib/model/room.js
+++ b/lib/mcs-core/lib/model/room.js
@@ -7,14 +7,18 @@
 
 const C = require('../constants/constants');
 const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
+const Logger = require('../utils/logger');
+const LOG_PREFIX = "[mcs-room]";
 
 module.exports = class Room {
-  constructor(id) {
+  constructor (id) {
     this.id = id;
     this._users = {};
-    this._emitter = GLOBAL_EVENT_EMITTER;
     this._conferenceFloor;
     this._contentFloor;
+    this._registeredEvents = [];
+    this._trackContentMediaDisconnection();
+    this._trackConferenceMediaDisconnection();
   }
 
   getUser (id) {
@@ -25,52 +29,97 @@ module.exports = class Room {
     return Object.keys(this._users).map(uk => this._users[uk].getUserInfo());
   }
 
-  getConferenceFloor() {
-    return this._conferenceFloor.id;
+  getConferenceFloor () {
+    return this._conferenceFloor? this._conferenceFloor.id : null;
   }
 
-  getContentFloor() {
-    return this._contentFloor.id;
+  getContentFloor () {
+    return this._contentFloor? this._contentFloor.id : null;
   }
 
   setUser (user) {
     this._users[user.id] = user;
-    this._emitter.emit(C.EVENT.USER_JOINED, { roomId: this.id, user: user.getUserInfo() });
+    GLOBAL_EVENT_EMITTER.emit(C.EVENT.USER_JOINED, { roomId: this.id, user: user.getUserInfo() });
   }
 
-  setConferenceFloor(media) {
+  setConferenceFloor (media) {
     this._conferenceFloor = media;
     const mediaInfo = media.getMediaInfo();
-    this._emitter.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, media: mediaInfo});
+    GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, media: mediaInfo});
     return mediaInfo;
   }
 
-  setContentFloor(media) {
+  setContentFloor (media) {
     this._contentFloor = media.getApplicationMedia();
     const mediaInfo = this._contentFloor.getMediaInfo();
-    this._emitter.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, media: mediaInfo});
+    GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, media: mediaInfo});
     return mediaInfo;
   }
 
-  releaseConferenceFloor(mediaId) {
-    if (this._conferenceFloor.id === mediaId) {
+  releaseConferenceFloor () {
+    if (this.getConferenceFloor()) {
       this._conferenceFloor = null
-      this._emitter.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, media: {}});
+      GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONFERENCE_FLOOR_CHANGED, { roomId: this.id, media: {}});
     }
   }
 
-  releaseContentFloor(mediaId) {
-    this._contentFloor = null
-    this._emitter.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, media: {}}) ;
+  releaseContentFloor () {
+    if (this.getContentFloor()) {
+      this._contentFloor = null;
+      GLOBAL_EVENT_EMITTER.emit(C.EVENT.CONTENT_FLOOR_CHANGED, { roomId: this.id, media: {}}) ;
+    }
+  }
+
+  _registerEvent (event, callback) {
+    this._registeredEvents.push({ event, callback });
+  }
+
+  _trackContentMediaDisconnection () {
+    // Listen for media disconnections and clear the content floor state when needed
+    // Used when devices ungracefully disconnect from the system
+    const clearContentFloor = (event) => {
+      const { mediaId, roomId, mediaSessionId } = event;
+      const contentFloorId = this.getContentFloor();
+
+      if (roomId === this.id && (mediaId === contentFloorId || mediaSessionId === contentFloorId)) {
+        this.releaseContentFloor(contentFloorId);
+      }
+    };
+
+    GLOBAL_EVENT_EMITTER.on(C.EVENT.MEDIA_DISCONNECTED, clearContentFloor);
+    this._registerEvent(C.EVENT.MEDIA_DISCONNECTED, clearContentFloor);
+  }
+
+  _trackConferenceMediaDisconnection () {
+    // Listen for media disconnections and clear the conference floor state when needed
+    // Used when devices ungracefully disconnect from the system
+    const clearConferenceFloor = (event) => {
+      const { mediaId, roomId, mediaSessionId } = event;
+      const conferenceFloorId = this.getConferenceFloor();
+
+      if (roomId === this.id && (mediaId === conferenceFloorId || mediaSessionId === conferenceFloorId)) {
+        this.releaseConferenceFloor(conferenceFloorId);
+      }
+    };
+
+    GLOBAL_EVENT_EMITTER.on(C.EVENT.MEDIA_DISCONNECTED, clearConferenceFloor);
+    this._registerEvent(C.EVENT.MEDIA_DISCONNECTED, clearConferenceFloor);
   }
 
   destroyUser(userId) {
-    this._emitter.emit(C.EVENT.USER_LEFT, { roomId: this.id,  userId });
+    GLOBAL_EVENT_EMITTER.emit(C.EVENT.USER_LEFT, { roomId: this.id,  userId });
     if (this._users[userId]) {
       delete this._users[userId];
       if (Object.keys(this._users).length <= 0) {
-        this._emitter.emit(C.EVENT.ROOM_EMPTY, this.id);
+        GLOBAL_EVENT_EMITTER.emit(C.EVENT.ROOM_EMPTY, this.id);
       }
     }
+  }
+
+  destroy () {
+    Logger.debug(LOG_PREFIX, "Destroying room", this.id);
+    this._registeredEvents.forEach(({ event, callback }) => {
+      GLOBAL_EVENT_EMITTER.removeListener(event, callback);
+    });
   }
 }

--- a/lib/mcs-core/lib/model/sdp-media.js
+++ b/lib/mcs-core/lib/model/sdp-media.js
@@ -68,6 +68,7 @@ module.exports = class SDPMedia extends Media {
   fillMediaTypes () {
     this.mediaTypes.video = this.offer.hasAvailableVideoCodec() ? this.offer.getDirection('video') : false;
     this.mediaTypes.audio = this.offer.hasAvailableAudioCodec() ? this.offer.getDirection('audio') : false;
+    this.mediaTypes.content = this.offer.hasContent() ? this.offer.getDirection('content') : false;
   }
 
   addIceCandidate (candidate) {

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -89,6 +89,7 @@ module.exports = class SDPSession extends MediaSession {
           this.medias = this.medias.concat(contentMedias);
 
           const contentAnswer = this.getAnswer();
+          // TODO move the content:slides appendage to the kurento adapter
           this.setAnswer(contentAnswer + "a=content:slides\r\n");
           return resolve(contentAnswer + "a=content:slides\r\n");
         }

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -168,15 +168,23 @@ module.exports = class User {
 
   async leave () {
     const sessions = Object.keys(this._mediaSessions);
-    let stopProcedures = [];
-    Logger.info("[mcs-sfu-user] User sessions will be killed");
+    Logger.info("[mcs-sfu-user] User", this.id, "wants to leave and its media sessions will be killed");
 
     try {
-      for (let i = 0; i < sessions.length; i++) {
-        stopProcedures.push(this.stopSession(sessions[i]));
-      }
+      sessions.forEach(async sk => {
+        try {
+          await this.stopSession(sk);
+        } catch (e) {
+          // Error on stopping, it was probably a MEDIA_NOT_FOUND error, hence
+          // we just delete the session if it's still allocated
+          this._handleError(e);
+          if (this._mediaSessions[sk]) {
+            delete this._mediaSessions[sk];
+          }
+        }
+      });
 
-      return Promise.all(stopProcedures);
+      return Promise.resolve(sessions);
     }
     catch (err) {
       err = this._handleError(err);

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -33,6 +33,7 @@ module.exports = class User {
         resolve(answer);
       }
       catch (err) {
+        await this.stopSession(sessionId);
         return reject(this._handleError(err));
       }
     });

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -206,9 +206,20 @@ module.exports = class User {
   }
 
   _trackMediaDisconnection(mediaSession) {
-    const deleteMedia = ({ mediaSessionId }) => {
+    const deleteMedia = async ({ mediaSessionId }) => {
       if (mediaSessionId === mediaSession.id) {
         Logger.info("[mcs-user] Media", mediaSessionId, "stopped.");
+        try {
+          await mediaSession.stop();
+        } catch (e) {
+          Logger.error(LOG_PREFIX, "Failed to stop session", mediaSessionId, "on child media disconnection. Cleaning it and emitting the disconnection event on its behalf");
+          GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, {
+            roomId: mediaSession.roomId,
+            mediaId: mediaSession.id,
+            mediaSessionId: mediaSession.id
+          });
+        }
+
         delete this._mediaSessions[mediaSessionId] ;
         GLOBAL_EVENT_EMITTER.removeListener(C.EVENT.MEDIA_DISCONNECTED, deleteMedia);
       }

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -121,15 +121,28 @@ module.exports = class SdpWrapper {
   }
 
   getDirection (type) {
-    let direction;
-    const media = this._jsonSdp.media.find(m => m.type === type);
-    if (media == null || media.direction == null) {
-      direction = 'sendrecv';
-    } else  {
-      direction = media.direction;
+    let direction, media;
+    const fetchDirection = (m) => {
+      if (m == null || m.direction == null) {
+        return 'sendrecv';
+      } else  {
+        return media.direction;
+      }
     }
 
-    return direction
+    // If we're fetching the content direciton, we go for the video direction
+    // because it's the only media type currently supported for content
+    if (type === 'content') {
+      if (this.contentVideoSdp) {
+        const parsedContentSDP = transform.parse(this.contentVideoSdp);
+        media = parsedContentSDP.media.find(m => m.type === 'video');
+        return fetchDirection(media);
+      }
+      return false;
+    }
+
+    media = this._jsonSdp.media.find(m => m.type === type);
+    return fetchDirection(media);
   }
 
   /**
@@ -174,6 +187,12 @@ module.exports = class SdpWrapper {
       const hasContentSlides = ml.invalid? ml.invalid[0].value.includes('slides') : false;
       return ml.type === "video" && hasContentSlides;
     });
+
+    // No content:slides media in this one
+    if (res.media.length <= 0) {
+      return;
+    }
+
     var mangledSdp = transform.write(res);
     if(typeof mangledSdp != undefined && mangledSdp && mangledSdp != "") {
       return mangledSdp;
@@ -435,7 +454,6 @@ module.exports = class SdpWrapper {
 
     this._mediaCapabilities.hasVideo = this._hasVideo();
     this._mediaCapabilities.hasAudio = this._hasAudio();
-    this._mediaCapabilities.hasContent = this._hasMultipleVideo();
     this._mediaCapabilities.hasAvailableVideoCodec = this._hasAvailableVideoCodec();
     this._mediaCapabilities.hasAvailableAudioCodec = this._hasAvailableAudioCodec();
     this.sessionDescriptionHeader = SdpWrapper.getSessionDescription(description);
@@ -443,6 +461,7 @@ module.exports = class SdpWrapper {
     this.mainVideoSdp = this.getMainDescription(description);
     this.partialDescriptors = SdpWrapper.getPartialDescriptions(description);
     this.contentVideoSdp = this.getContentDescription(description);
+    this._mediaCapabilities.hasContent = this.contentVideoSdp? true : false;
 
     return;
   }

--- a/lib/screenshare/ScreenshareManager.js
+++ b/lib/screenshare/ScreenshareManager.js
@@ -20,6 +20,9 @@ module.exports = class ScreenshareManager extends BaseManager {
     this.sfuApp = C.SCREENSHARE_APP;
     this.messageFactory(this._onMessage);
     this._iceQueues = {};
+    this.mcs.on(C.MCS_CONNECTED, () => {
+      this.mcs.onEvent('roomCreated', 'all', this._handleRoomCreated.bind(this));
+    });
   }
 
   async _onMessage(message) {
@@ -127,6 +130,34 @@ module.exports = class ScreenshareManager extends BaseManager {
           ...errorMessage,
         }), C.FROM_SCREENSHARE);
         break;
+    }
+  }
+
+  _handleRoomCreated (event) {
+    const { room } = event;
+    this.mcs.onEvent('roomDestroyed', room, (event) => {
+      Logger.debug(this._logPrefix, "Room", event.room, "destroyed");
+      try {
+        this._stopSession(room);
+      } catch (e) {
+        Logger.error(LOG_PREFIX, this._handleError(this._logPrefix, null, null, null, e));
+      }
+    });
+    this.mcs.onEvent('contentFloorChanged', room, this._handleContentFloorChanged.bind(this));
+  }
+
+  async _handleContentFloorChanged (event) {
+    const { roomId, floor, previousFloor } = event;
+
+    Logger.debug(this._logPrefix, "Content floor changed", { roomId }, { floor });
+
+    try {
+      if (floor == null) {
+        // Content floor was released, forcibly stop the session if it wasn't yet
+        await this._stopSession(roomId);
+      }
+    } catch (e) {
+      Logger.error(LOG_PREFIX, this._handleError(this._logPrefix, null, null, null, e));
     }
   }
 

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -302,6 +302,17 @@ module.exports = class Screenshare extends BaseProvider {
     }
   }
 
+  async _fetchContentFloor () {
+    try {
+      const { floor } = await this.mcs.getContentFloor(this._voiceBridge);
+      const contentFloorId = floor.mediaId;
+      Logger.debug(LOG_PREFIX, "Content floor for", this._voiceBridge, "is", contentFloorId);
+      return contentFloorId;
+    } catch (e) {
+      throw e;
+    }
+  }
+
   async _upstartRTPStream () {
     try {
       const sendVideoPort = MediaHandler.getVideoPort();
@@ -313,8 +324,7 @@ module.exports = class Screenshare extends BaseProvider {
       }
 
       if (this._presenterEndpoint == null) {
-        const contentFloorId = await this.mcs.getContentFloor(this._voiceBridge);
-        this._presenterEndpoint = contentFloorId;
+        this._presenterEndpoint = await this._fetchContentFloor();;
       }
 
       const { mediaId, answer } = await this.mcs.subscribe(this.mcsUserId,
@@ -354,8 +364,7 @@ module.exports = class Screenshare extends BaseProvider {
         }
 
         if (this._presenterEndpoint == null) {
-          const contentFloorId = await this.mcs.getContentFloor(this._voiceBridge);
-          this._presenterEndpoint = contentFloorId;
+          this._presenterEndpoint = await this._fetchContentFloor();
         }
 
         const { mediaId, answer } = await this.mcs.subscribe(this.mcsUserId,

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -110,8 +110,8 @@ module.exports = class Video extends BaseProvider {
           if (!this.notFlowingTimeout) {
             this.notFlowingTimeout = setTimeout(() => {
               if (this.shared) {
+                Logger.warn(LOG_PREFIX, "Media NOT_FLOWING timeout hit for", this.streamName);
                 this.sendPlayStop();
-                this.status = C.MEDIA_STOPPED;
                 clearTimeout(this.notFlowingTimeout);
                 delete this.notFlowingTimeout;
               }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.2.5",
+  "version": "2.3.0-dev.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -333,9 +333,9 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
-      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -346,9 +346,9 @@
       "integrity": "sha1-p7GqlP/ADpB4wuuibiBL2Hzyy7k="
     },
     "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -417,9 +417,9 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "event-target-shim": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.0.tgz",
-      "integrity": "sha512-vu4tlY5xqMEGj/rzuDHxfvm9Kk2562O5h58i8xwnkMkv/yqmBqBcDJt/vGBrOBbCKuVc5eV3ghYxAX9YUhyi0w=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter2": {
       "version": "5.0.1",
@@ -457,20 +457,25 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "follow-redirects": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
-      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "requires": {
-        "debug": "=3.1.0"
+        "debug": "^3.2.6"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -791,12 +796,12 @@
       }
     },
     "jwa": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.2.0.tgz",
-      "integrity": "sha512-Grku9ZST5NNQ3hqNUodSkDfEBqAmGA1R8yiyPHOnLzEKI0GaCQC/XhFmsheXYuXzFQJdILbh+lYBiliqG5R/Vg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.3.0.tgz",
+      "integrity": "sha512-SxObIyzv9a6MYuZYaSN6DhSm9j3+qkokwvCB0/OTSV5ylPq1wUQiygZQcHT5Qlux0I5kmISx3J86TxKhuefItg==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.10",
+        "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -895,7 +900,7 @@
       }
     },
     "mcs-js": {
-      "version": "git+https://github.com/mconftec/mcs-js.git#a6bf928cda88d656763e00cff59539591f38bc75",
+      "version": "git+https://github.com/mconftec/mcs-js.git#76857a4e28243c354d3e7e952b756522fffb80a2",
       "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.5-dev",
       "requires": {
         "uuid": "3.3.2",
@@ -923,16 +928,16 @@
       "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
     },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "~1.38.0"
       }
     },
     "minimatch": {
@@ -1203,22 +1208,22 @@
       }
     },
     "request-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
-      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.4.tgz",
+      "integrity": "sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==",
       "requires": {
         "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "^4.17.11"
       }
     },
     "resolve": {
@@ -1350,9 +1355,9 @@
       },
       "dependencies": {
         "escodegen": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-          "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+          "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
           "requires": {
             "esprima": "^3.1.3",
             "estraverse": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -895,8 +895,8 @@
       }
     },
     "mcs-js": {
-      "version": "git+https://github.com/mconftec/mcs-js.git#22be69f25d19fa1616124559b2d1b2147bf4e83a",
-      "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.4",
+      "version": "git+https://github.com/mconftec/mcs-js.git#a6bf928cda88d656763e00cff59539591f38bc75",
+      "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.5-dev",
       "requires": {
         "uuid": "3.3.2",
         "ws": "6.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.3.0-dev.1",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -900,8 +900,8 @@
       }
     },
     "mcs-js": {
-      "version": "git+https://github.com/mconftec/mcs-js.git#76857a4e28243c354d3e7e952b756522fffb80a2",
-      "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.5-dev",
+      "version": "git+https://github.com/mconftec/mcs-js.git#e1fef9493d910efbcbfd34b850a01baedf1d3ec9",
+      "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.5",
       "requires": {
         "uuid": "3.3.2",
         "ws": "6.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1487,8 +1487,8 @@
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "mcs-js": {
-      "version": "git+https://github.com/mconftec/mcs-js.git#3f54e5eacf970b099ebffd0b738f48de2d6886b7",
-      "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.4-dev",
+      "version": "git+https://github.com/mconftec/mcs-js.git#22be69f25d19fa1616124559b2d1b2147bf4e83a",
+      "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.4",
       "requires": {
         "uuid": "3.3.2",
         "ws": "6.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,27 +22,14 @@
       },
       "dependencies": {
         "js-yaml": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "version": "3.12.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+          "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
           }
         }
-      }
-    },
-    "@types/babel-types": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.4.tgz",
-      "integrity": "sha512-WiZhq3SVJHFRgRYLXvpf65XnV6ipVHhnNaNvE8yCimejrGglkg38kEj0JcizqwSHxmPSjcTlig/6JouxLGEhGw=="
-    },
-    "@types/babylon": {
-      "version": "6.16.4",
-      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.4.tgz",
-      "integrity": "sha512-8dZMcGPno3g7pJ/d0AyJERo+lXh9i1JhDuCUs+4lNIN9eUe5Yh6UCLrpgSEi05Ve2JMLauL2aozdvKwNL0px1Q==",
-      "requires": {
-        "@types/babel-types": "*"
       }
     },
     "JSONSelect": {
@@ -52,40 +39,19 @@
     },
     "JSONStream": {
       "version": "0.10.0",
-      "resolved": "http://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
       "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
       "requires": {
         "jsonparse": "0.0.5",
         "through": ">=2.2.7 <3"
       }
     },
-    "accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+    "abort-controller": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-2.0.2.tgz",
+      "integrity": "sha512-JXEYGxxMwiNl9EUdLysK0K0DwB7ENw6KeeaLHgofijTfJYPB/vOer3Mb+IcP913dCfWiQsd05MmVNl0H5PanrQ==",
       "requires": {
-        "mime-types": "~2.1.18",
-        "negotiator": "0.6.1"
-      }
-    },
-    "acorn": {
-      "version": "3.3.0",
-      "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-    },
-    "acorn-globals": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-      "requires": {
-        "acorn": "^4.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-        }
+        "event-target-shim": "^5.0.0"
       }
     },
     "agent-base": {
@@ -97,43 +63,14 @@
       }
     },
     "ajv": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-      "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+      "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "apparatus": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
-      "integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
-      "optional": true,
-      "requires": {
-        "sylvester": ">= 0.0.8"
       }
     },
     "argparse": {
@@ -143,11 +80,6 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "array-flatten": {
-      "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "asap": {
       "version": "2.0.6",
@@ -204,31 +136,6 @@
         "is-buffer": "^1.1.5"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-    },
     "backoff": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
@@ -274,23 +181,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
       "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
-    "body-parser": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-      "requires": {
-        "bytes": "3.0.0",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
-        "iconv-lite": "0.4.23",
-        "on-finished": "~2.3.0",
-        "qs": "6.5.2",
-        "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -315,51 +205,19 @@
       }
     },
     "build-url": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/build-url/-/build-url-1.3.1.tgz",
-      "integrity": "sha512-G45VmLsojWFjnKKqZhpxJyZo+wx/iyv3u2eTLF/8ksaLJ7D4+61ykf9NxJWqbOFXYgxUDm9ccOM88BhVaTDnmQ=="
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/build-url/-/build-url-1.3.2.tgz",
+      "integrity": "sha512-L6H0SvNHEQC3GaTh07IdQ04BbERtccx6rHEBpprU2vPerYY2n0qyU2jb2Un5T7xgGhoCrP5Br1ThO6jH3pR5ow=="
     },
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
       "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
     },
-    "bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-    },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
-    },
-    "character-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
-      "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
-      "requires": {
-        "is-regex": "^1.0.3"
-      }
     },
     "charenc": {
       "version": "0.0.2",
@@ -371,46 +229,9 @@
       "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.2.1.tgz",
       "integrity": "sha1-c82KrWXZ4VBfmvF0TTt5wVJ2gqU="
     },
-    "clean-css": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
-      "requires": {
-        "source-map": "~0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
-        }
-      }
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
     "colors": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
       "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
     },
     "combined-stream": {
@@ -433,48 +254,12 @@
     },
     "config": {
       "version": "1.30.0",
-      "resolved": "http://registry.npmjs.org/config/-/config-1.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/config/-/config-1.30.0.tgz",
       "integrity": "sha1-HWCp81NIoTwXV5jThOgaWhbDum4=",
       "requires": {
         "json5": "0.4.0",
         "os-homedir": "1.0.2"
       }
-    },
-    "constantinople": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
-      "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
-      "requires": {
-        "@types/babel-types": "^7.0.0",
-        "@types/babylon": "^6.16.2",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0"
-      }
-    },
-    "content-disposition": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
-    },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
-    "core-js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
-      "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -485,11 +270,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-    },
-    "css-parse": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
-      "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs="
     },
     "cycle": {
       "version": "1.0.3",
@@ -512,11 +292,6 @@
         "ms": "2.0.0"
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -526,16 +301,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "docker-modem": {
       "version": "0.3.7",
@@ -547,11 +312,6 @@
         "readable-stream": "~1.0.26-4",
         "split-ca": "^1.0.0"
       }
-    },
-    "doctypes": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
-      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
     },
     "double-ended-queue": {
       "version": "2.1.0-0",
@@ -580,24 +340,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
-    "encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-    },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "error-tojson": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/error-tojson/-/error-tojson-0.0.1.tgz",
@@ -615,11 +357,6 @@
       "requires": {
         "es6-promise": "^4.0.3"
       }
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escodegen": {
       "version": "0.0.21",
@@ -679,59 +416,15 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
-    "etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    "event-target-shim": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.0.tgz",
+      "integrity": "sha512-vu4tlY5xqMEGj/rzuDHxfvm9Kk2562O5h58i8xwnkMkv/yqmBqBcDJt/vGBrOBbCKuVc5eV3ghYxAX9YUhyi0w=="
     },
     "eventemitter2": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
       "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI="
-    },
-    "express": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
-      "requires": {
-        "accepts": "~1.3.5",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.18.3",
-        "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.1.1",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
-        "qs": "6.5.2",
-        "range-parser": "~1.2.0",
-        "safe-buffer": "5.1.2",
-        "send": "0.16.2",
-        "serve-static": "1.13.2",
-        "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "dependencies": {
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-        }
-      }
     },
     "extend": {
       "version": "3.0.2",
@@ -762,36 +455,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-    },
-    "finalhandler": {
-      "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-      "requires": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
-      },
-      "dependencies": {
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-        }
-      }
-    },
-    "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
     },
     "follow-redirects": {
       "version": "1.6.1",
@@ -826,31 +489,17 @@
         "mime-types": "^2.1.12"
       }
     },
-    "forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-    },
-    "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
     "gaxios": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.2.7.tgz",
-      "integrity": "sha512-E0tFhk7gqyLReJeBE/APaokrVNJ9zVHuuBKNTXTRhfItUhV0pW42NzzOJiK5kKup/4R+2e/SXJRRp2LT5huF8Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.7.0.tgz",
+      "integrity": "sha512-2SaZTtaEgnSMgRrBVnPA5O9Tc8xWfnL48fuxFL7zOHZwnam3HiNOkoosnRgnkNBZoEZrH1Aja3wMCrrDtOEqUw==",
       "requires": {
+        "abort-controller": "^2.0.2",
         "extend": "^3.0.2",
         "https-proxy-agent": "^2.2.1",
         "node-fetch": "^2.2.0"
@@ -865,11 +514,6 @@
         "extend": "^3.0.1",
         "retry-axios": "0.3.2"
       }
-    },
-    "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
     "getpass": {
       "version": "0.1.7",
@@ -905,17 +549,6 @@
         "lodash.isstring": "^4.0.1",
         "lru-cache": "^4.1.3",
         "semver": "^5.5.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        }
       }
     },
     "google-p12-pem": {
@@ -925,13 +558,6 @@
       "requires": {
         "node-forge": "^0.7.5",
         "pify": "^4.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-        }
       }
     },
     "googleapis": {
@@ -954,19 +580,7 @@
         "qs": "^6.5.2",
         "url-template": "^2.0.8",
         "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-        }
       }
-    },
-    "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "gtoken": {
       "version": "2.3.2",
@@ -978,18 +592,6 @@
         "jws": "^3.1.5",
         "mime": "^2.2.0",
         "pify": "^4.0.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-          "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-        }
       }
     },
     "har-schema": {
@@ -1004,30 +606,6 @@
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
-    "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
-    },
-    "http-errors": {
-      "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-      "requires": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-signature": {
@@ -1064,14 +642,6 @@
         }
       }
     },
-    "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1087,84 +657,19 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-    },
-    "ipaddr.js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
-    },
-    "is-expression": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
-      "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
-      "requires": {
-        "acorn": "~4.0.2",
-        "object-assign": "^4.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-        }
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "isarray": {
       "version": "0.0.1",
@@ -1212,11 +717,6 @@
         "nomnom": "1.5.2"
       }
     },
-    "js-stringify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
-    },
     "js-yaml": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
@@ -1248,7 +748,7 @@
     },
     "json5": {
       "version": "0.4.0",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
       "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
     },
     "jsonparse": {
@@ -1274,7 +774,7 @@
         },
         "underscore": {
           "version": "1.7.0",
-          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
           "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
         }
       }
@@ -1288,15 +788,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      }
-    },
-    "jstransformer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
-      "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
-      "requires": {
-        "is-promise": "^2.0.0",
-        "promise": "^7.0.1"
       }
     },
     "jwa": {
@@ -1318,43 +809,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "kue": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/kue/-/kue-0.11.6.tgz",
-      "integrity": "sha512-56Jic22qSqdJ3nNpkhVr6RUx/QKalfdBdU0m70hgBKEkhBAgdt6Qr74evec+bM+LGmNbEC6zGGDskX4mcgBYcQ==",
-      "requires": {
-        "body-parser": "^1.12.2",
-        "express": "^4.12.2",
-        "lodash": "^4.0.0",
-        "nib": "~1.1.2",
-        "node-redis-warlock": "~0.2.0",
-        "pug": "^2.0.0-beta3",
-        "redis": "~2.6.0-2",
-        "reds": "^0.2.5",
-        "stylus": "~0.54.5",
-        "yargs": "^4.0.0"
-      },
-      "dependencies": {
-        "redis": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
-          "integrity": "sha1-h8Hv9KSJ+Utwhx89CLaYjyOpVoc=",
-          "requires": {
-            "double-ended-queue": "^2.1.0-0",
-            "redis-commands": "^1.2.0",
-            "redis-parser": "^2.0.0"
-          }
-        }
-      }
-    },
     "kurento-client": {
       "version": "git+https://github.com/mconf/kurento-client-js.git#09986b21db44fdc015706d7b01bece1728094d4c",
       "from": "git+https://github.com/mconf/kurento-client-js.git#mconf",
@@ -1372,21 +826,6 @@
         "promise": "7.1.1",
         "promisecallback": "0.0.4",
         "reconnect-ws": "github:KurentoForks/reconnect-ws#f287385d75861654528c352e60221f95c9209f8a"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "promise": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-          "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        }
       }
     },
     "kurento-client-core": {
@@ -1422,19 +861,6 @@
         }
       }
     },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1449,42 +875,24 @@
       "resolved": "https://registry.npmjs.org/lex-parser/-/lex-parser-0.1.4.tgz",
       "integrity": "sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA="
     },
-    "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      }
-    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-    },
     "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "mcs-js": {
       "version": "git+https://github.com/mconftec/mcs-js.git#22be69f25d19fa1616124559b2d1b2147bf4e83a",
@@ -1504,30 +912,15 @@
         }
       }
     },
-    "media-typer": {
-      "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
     "memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
     },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-    },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
     },
     "mime-db": {
       "version": "1.37.0",
@@ -1551,16 +944,23 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "ms": {
@@ -1569,38 +969,14 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
     "nanoid": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.3.4.tgz",
       "integrity": "sha512-4ug4BsuHxiVHoRUe1ud6rUFT3WUMmjXt1W0quL0CviZQANdan7D8kqN5/maw53hmAApY/jfzMRkC57BNNs60ZQ=="
-    },
-    "natural": {
-      "version": "0.2.1",
-      "resolved": "http://registry.npmjs.org/natural/-/natural-0.2.1.tgz",
-      "integrity": "sha1-HrUVap2QtFkZSeIOlOvHe7Iznto=",
-      "optional": true,
-      "requires": {
-        "apparatus": ">= 0.0.9",
-        "sylvester": ">= 0.0.12",
-        "underscore": ">=1.3.1"
-      }
-    },
-    "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-    },
-    "nib": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/nib/-/nib-1.1.2.tgz",
-      "integrity": "sha1-amnt5AgblcDe+L4CSkyK4MLLtsc=",
-      "requires": {
-        "stylus": "0.54.5"
-      }
     },
     "node-docker-api": {
       "version": "1.1.22",
@@ -1621,38 +997,6 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
       "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
-    "node-redis-scripty": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/node-redis-scripty/-/node-redis-scripty-0.0.5.tgz",
-      "integrity": "sha1-S/LTZattqyAswIt6xj+PVarcliU=",
-      "requires": {
-        "extend": "^1.2.1",
-        "lru-cache": "^2.5.0"
-      },
-      "dependencies": {
-        "extend": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-          "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
-        }
-      }
-    },
-    "node-redis-warlock": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/node-redis-warlock/-/node-redis-warlock-0.2.0.tgz",
-      "integrity": "sha1-VjlbmUyCjo4y9qrlO5O27fzZeZA=",
-      "requires": {
-        "node-redis-scripty": "0.0.5",
-        "uuid": "^2.0.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        }
-      }
-    },
     "nomnom": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
@@ -1664,44 +1008,15 @@
       "dependencies": {
         "underscore": {
           "version": "1.1.7",
-          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
           "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA="
         }
       }
-    },
-    "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "requires": {
-        "ee-first": "1.1.1"
-      }
     },
     "once": {
       "version": "1.4.0",
@@ -1731,41 +1046,12 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "^1.0.0"
-      }
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "^1.2.0"
-      }
-    },
-    "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
-    },
-    "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "requires": {
-        "pinkie-promise": "^2.0.0"
-      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
@@ -1773,43 +1059,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
-    "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
-    "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -1818,14 +1076,14 @@
     },
     "promiscuous": {
       "version": "0.6.0",
-      "resolved": "http://registry.npmjs.org/promiscuous/-/promiscuous-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/promiscuous/-/promiscuous-0.6.0.tgz",
       "integrity": "sha1-VAFM09Ysr+gx4zVJkMBf9beMiJI=",
       "optional": true
     },
     "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -1835,138 +1093,15 @@
       "resolved": "https://registry.npmjs.org/promisecallback/-/promisecallback-0.0.4.tgz",
       "integrity": "sha1-uTTxPATkQ2IrTWbeTkLqX2zmbnQ="
     },
-    "proxy-addr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
-      "requires": {
-        "forwarded": "~0.1.2",
-        "ipaddr.js": "1.8.0"
-      }
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
-    },
-    "pug": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.3.tgz",
-      "integrity": "sha1-ccuoJTfJWl6rftBGluQiH1Oqh44=",
-      "requires": {
-        "pug-code-gen": "^2.0.1",
-        "pug-filters": "^3.1.0",
-        "pug-lexer": "^4.0.0",
-        "pug-linker": "^3.0.5",
-        "pug-load": "^2.0.11",
-        "pug-parser": "^5.0.0",
-        "pug-runtime": "^2.0.4",
-        "pug-strip-comments": "^1.0.3"
-      }
-    },
-    "pug-attrs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.3.tgz",
-      "integrity": "sha1-owlflw5kFR972tlX7vVftdeQXRU=",
-      "requires": {
-        "constantinople": "^3.0.1",
-        "js-stringify": "^1.0.1",
-        "pug-runtime": "^2.0.4"
-      }
-    },
-    "pug-code-gen": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.1.tgz",
-      "integrity": "sha1-CVHsgyJddNjPxHan+Zolm199BQw=",
-      "requires": {
-        "constantinople": "^3.0.1",
-        "doctypes": "^1.1.0",
-        "js-stringify": "^1.0.1",
-        "pug-attrs": "^2.0.3",
-        "pug-error": "^1.3.2",
-        "pug-runtime": "^2.0.4",
-        "void-elements": "^2.0.1",
-        "with": "^5.0.0"
-      }
-    },
-    "pug-error": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.2.tgz",
-      "integrity": "sha1-U659nSm7A89WRJOgJhCfVMR/XyY="
-    },
-    "pug-filters": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.0.tgz",
-      "integrity": "sha1-JxZVVbwEwjbkqisDZiRt+gIbYm4=",
-      "requires": {
-        "clean-css": "^4.1.11",
-        "constantinople": "^3.0.1",
-        "jstransformer": "1.0.0",
-        "pug-error": "^1.3.2",
-        "pug-walk": "^1.1.7",
-        "resolve": "^1.1.6",
-        "uglify-js": "^2.6.1"
-      }
-    },
-    "pug-lexer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.0.0.tgz",
-      "integrity": "sha1-IQwYRX7y4XYCQnQMXmR715TOwng=",
-      "requires": {
-        "character-parser": "^2.1.1",
-        "is-expression": "^3.0.0",
-        "pug-error": "^1.3.2"
-      }
-    },
-    "pug-linker": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.5.tgz",
-      "integrity": "sha1-npp65ABWgtAn3uuWsAD4juuDoC8=",
-      "requires": {
-        "pug-error": "^1.3.2",
-        "pug-walk": "^1.1.7"
-      }
-    },
-    "pug-load": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.11.tgz",
-      "integrity": "sha1-5kjlftET/iwfRdV4WOorrWvAFSc=",
-      "requires": {
-        "object-assign": "^4.1.0",
-        "pug-walk": "^1.1.7"
-      }
-    },
-    "pug-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.0.tgz",
-      "integrity": "sha1-45Stmz/KkxI5QK/4hcBuRKt+aOQ=",
-      "requires": {
-        "pug-error": "^1.3.2",
-        "token-stream": "0.0.1"
-      }
-    },
-    "pug-runtime": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.4.tgz",
-      "integrity": "sha1-4XjhvaaKsujArPybztLFT9iM61g="
-    },
-    "pug-strip-comments": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.3.tgz",
-      "integrity": "sha1-8VWVkiBu3G+FMQ2s9K+0igJa9Z8=",
-      "requires": {
-        "pug-error": "^1.3.2"
-      }
-    },
-    "pug-walk": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.7.tgz",
-      "integrity": "sha1-wA1cUSi6xYBr7BXSt+fNq+QlMfM="
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -1978,41 +1113,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
-    "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-    },
-    "raw-body": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-      "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
-        "unpipe": "1.0.0"
-      }
-    },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      }
-    },
     "readable-id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/readable-id/-/readable-id-1.0.0.tgz",
@@ -2023,7 +1123,7 @@
     },
     "readable-stream": {
       "version": "1.0.34",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -2075,34 +1175,6 @@
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
-    "reds": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/reds/-/reds-0.2.5.tgz",
-      "integrity": "sha1-OKdn92Y810kDaEhpfYLHT9KbwB8=",
-      "optional": true,
-      "requires": {
-        "natural": "^0.2.0",
-        "redis": "^0.12.1"
-      },
-      "dependencies": {
-        "redis": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz",
-          "integrity": "sha1-ZN92rQ/IrOuuvSoGReikj6xJGF4=",
-          "optional": true
-        }
-      }
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
@@ -2149,36 +1221,18 @@
         "lodash": "^4.13.1"
       }
     },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-    },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "retry-axios": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
       "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "requires": {
-        "align-text": "^0.1.1"
-      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -2197,61 +1251,13 @@
     },
     "sdp-transform": {
       "version": "2.4.1",
-      "resolved": "http://registry.npmjs.org/sdp-transform/-/sdp-transform-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.4.1.tgz",
       "integrity": "sha512-dCReSJ6NtCW6goKkKBEHcIknBS1pKejnMw+S3p3jl0PALPFrbjbreCyQ+CABtFxl2GXD2/05+C2q2gZP23dUWQ=="
     },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
-    },
-    "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-      "requires": {
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
-      },
-      "dependencies": {
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-        }
-      }
-    },
-    "serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-      "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
-        "send": "0.16.2"
-      }
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "sha1": {
       "version": "1.1.1",
@@ -2274,7 +1280,7 @@
     },
     "sip.js": {
       "version": "0.7.5",
-      "resolved": "http://registry.npmjs.org/sip.js/-/sip.js-0.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/sip.js/-/sip.js-0.7.5.tgz",
       "integrity": "sha1-hqznBRWU+RtFUb24EgoWxEli06I=",
       "requires": {
         "promiscuous": "^0.6.0",
@@ -2283,12 +1289,12 @@
       "dependencies": {
         "nan": {
           "version": "1.4.3",
-          "resolved": "http://registry.npmjs.org/nan/-/nan-1.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.3.tgz",
           "integrity": "sha1-xWtUBGmAY2lvWXQ1+RY8MSrqUAk="
         },
         "ws": {
           "version": "0.6.5",
-          "resolved": "http://registry.npmjs.org/ws/-/ws-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-0.6.5.tgz",
           "integrity": "sha1-8AhEAByjk7ADaB/zKDjnKlYNr9Q=",
           "requires": {
             "nan": "1.4.x",
@@ -2304,34 +1310,6 @@
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "optional": true
     },
-    "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
-    },
     "split-ca": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
@@ -2343,9 +1321,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -2401,112 +1379,25 @@
         }
       }
     },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      }
-    },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
-    "stylus": {
-      "version": "0.54.5",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
-      "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
-      "requires": {
-        "css-parse": "1.7.x",
-        "debug": "*",
-        "glob": "7.0.x",
-        "mkdirp": "0.5.x",
-        "sax": "0.5.x",
-        "source-map": "0.1.x"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "sax": {
-          "version": "0.5.8",
-          "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
-          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
-      }
-    },
-    "sylvester": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz",
-      "integrity": "sha1-KYexzivS84sNzio0OIiEv6RADqc="
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tinycolor": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
       "integrity": "sha1-MgtaUtg6u1l42Bo+iH1K77FaYWQ="
-    },
-    "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-    },
-    "token-stream": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
-      "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
     },
     "tough-cookie": {
       "version": "2.4.3",
@@ -2550,15 +1441,6 @@
         "prelude-ls": "~1.1.2"
       }
     },
-    "type-is": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
-      }
-    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -2566,40 +1448,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0"
-          }
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
     },
     "ultron": {
       "version": "1.0.2",
@@ -2610,11 +1458,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "uri-js": {
       "version": "4.2.2",
@@ -2645,29 +1488,10 @@
         }
       }
     },
-    "utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-    },
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",
@@ -2678,11 +1502,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
     },
     "websocket": {
       "version": "1.0.28",
@@ -2723,16 +1542,6 @@
         }
       }
     },
-    "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-    },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
-    },
     "winston": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.2.tgz",
@@ -2748,12 +1557,12 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         },
         "colors": {
           "version": "1.0.3",
-          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
         }
       }
@@ -2766,28 +1575,10 @@
         "mkdirp": "0.5.1"
       }
     },
-    "with": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
-      "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
-      "requires": {
-        "acorn": "^3.1.0",
-        "acorn-globals": "^3.0.0"
-      }
-    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -2830,13 +1621,8 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-    },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yaeti": {
       "version": "0.0.6",
@@ -2847,60 +1633,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yargs": {
-      "version": "4.8.1",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-      "requires": {
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "lodash.assign": "^4.0.3",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.1",
-        "which-module": "^1.0.0",
-        "window-size": "^0.2.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^2.4.1"
-      },
-      "dependencies": {
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "2.4.1",
-      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-      "requires": {
-        "camelcase": "^3.0.0",
-        "lodash.assign": "^4.0.6"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        }
-      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1487,8 +1487,8 @@
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "mcs-js": {
-      "version": "git+https://github.com/mconftec/mcs-js.git#8459420b4fd25261ee02e7823f47565b55b50727",
-      "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.3-dev",
+      "version": "git+https://github.com/mconftec/mcs-js.git#3f54e5eacf970b099ebffd0b738f48de2d6886b7",
+      "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.4-dev",
       "requires": {
         "uuid": "3.3.2",
         "ws": "6.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "js-yaml": "3.11.0",
     "kue": "0.11.6",
     "kurento-client": "git+https://github.com/mconf/kurento-client-js.git#mconf",
-    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.3-dev",
+    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.4-dev",
     "node-docker-api": "1.1.22",
     "readable-id": "1.0.0",
     "redis": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.3.0-dev.1",
+  "version": "2.3.0",
   "private": true,
   "scripts": {
     "start": "node server.js"
@@ -14,7 +14,7 @@
     "googleapis": "35.0.0",
     "js-yaml": "3.11.0",
     "kurento-client": "git+https://github.com/mconf/kurento-client-js.git#mconf",
-    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.5-dev",
+    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.5",
     "node-docker-api": "1.1.22",
     "readable-id": "1.0.0",
     "redis": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "private": true,
   "scripts": {
     "start": "node server.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.2.5",
+  "version": "2.3.0-dev.1",
   "private": true,
   "scripts": {
     "start": "node server.js"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "js-yaml": "3.11.0",
     "kue": "0.11.6",
     "kurento-client": "git+https://github.com/mconf/kurento-client-js.git#mconf",
-    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.4-dev",
+    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.4",
     "node-docker-api": "1.1.22",
     "readable-id": "1.0.0",
     "redis": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "googleapis": "35.0.0",
     "js-yaml": "3.11.0",
     "kurento-client": "git+https://github.com/mconf/kurento-client-js.git#mconf",
-    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.4",
+    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.5-dev",
     "node-docker-api": "1.1.22",
     "readable-id": "1.0.0",
     "redis": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "google-auth-library": "2.0.1",
     "googleapis": "35.0.0",
     "js-yaml": "3.11.0",
-    "kue": "0.11.6",
     "kurento-client": "git+https://github.com/mconf/kurento-client-js.git#mconf",
     "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.4",
     "node-docker-api": "1.1.22",


### PR DESCRIPTION
*CHANGELOG*:

* Version numbers now adhere to semantic versioning, hence the bump to 2.3.0;
* Bump `mcs-js` dep to the `0.0.5` release;
* Refactored the whole content/conference floor to follow the API changes and provide previous floor infos to API consumers. Also made it consistently answer either `MediaSession` or `Media` info objects;
* Reworked the `getMediaPipeline` and `transposeAndConnect` logic in the `kurento` adapter to avoid using `Kue` as a dependency due to race conditions. `Kue` is now removed from the app, reducing its size, and the race condition was natively fixed;
* Fixed an issue with the `connect`/`disconnect` type param comparison in `MediaSession` and `Media` which made some specific calls no-op. The `type` param implementation will be revisited in future version because it's currently a bit nonsensical;
* Properly handle failures on media negotiation and media state in the `freeswitch` adapter;
* Listen to `room*` and `contentFloor` events in the screenshare process to increase reliability against hanging screenshare sessions and also properly handle content that comes from sources other than its own process;
* Fixed an issue in the `video` process regarding webcam reconnections that would make it not send the `StopWebRTCShare` recording event and would leak media session on `mcs-core`;
* Properly cleanup media session when there was a negotiation failure in the controller side of `mcs-core`;
* Ignore MEDIA_NOT_FOUND errors on `leave` to avoid leaking media sessions;
* Added stub rembParams on media element creation in the kurento adapter;
  - This is a workaround/placeholder and will be revisited to fetch the bandwidth values from the configured media specs.