### PR TITLE
Map MCS and BBB users 1:1 

### DIFF
--- a/lib/audio/AudioManager.js
+++ b/lib/audio/AudioManager.js
@@ -42,6 +42,16 @@ module.exports = class AudioManager extends BaseManager {
           let meetingId = payload[C.MEETING_ID_2x];
           this._disconnectAllUsers(meetingId);
         });
+        this._bbbGW.on(C.USER_JOINED_VOICE_CONF_MESSAGE_2x, this._handleUserJoinedVoiceConf.bind(this));
+    }
+  }
+
+  async _handleUserJoinedVoiceConf (payload) {
+    const { meetingId, userId, callerNum, callerName, voiceConf } = payload;
+    try {
+      await this.mcs.join(voiceConf, 'SFU', { userId, name: callerName });
+    } catch (e) {
+      Logger.warn(this._logPrefix, "Failed to pre-start audio user", e);
     }
   }
 

--- a/lib/audio/AudioManager.js
+++ b/lib/audio/AudioManager.js
@@ -49,7 +49,9 @@ module.exports = class AudioManager extends BaseManager {
   async _handleUserJoinedVoiceConf (payload) {
     const { meetingId, userId, callerNum, callerName, voiceConf } = payload;
     try {
-      await this.mcs.join(voiceConf, 'SFU', { userId, name: callerName });
+      if (userId.startsWith("w_")) {
+        await this.mcs.join(voiceConf, 'SFU', { userId, name: callerName });
+      }
     } catch (e) {
       Logger.warn(this._logPrefix, "Failed to pre-start audio user", e);
     }

--- a/lib/audio/AudioManager.js
+++ b/lib/audio/AudioManager.js
@@ -43,17 +43,31 @@ module.exports = class AudioManager extends BaseManager {
           this._disconnectAllUsers(meetingId);
         });
         this._bbbGW.on(C.USER_JOINED_VOICE_CONF_MESSAGE_2x, this._handleUserJoinedVoiceConf.bind(this));
+        this._bbbGW.on(C.USER_LEFT_MEETING_2x, this._handleUserLeftMeeting.bind(this));
     }
   }
 
   async _handleUserJoinedVoiceConf (payload) {
-    const { meetingId, userId, callerNum, callerName, voiceConf } = payload;
+    const { userId, callerName, voiceConf } = payload;
     try {
       if (userId.startsWith("w_")) {
         await this.mcs.join(voiceConf, 'SFU', { userId, name: callerName });
       }
     } catch (e) {
       Logger.warn(this._logPrefix, "Failed to pre-start audio user", e);
+    }
+  }
+
+  async _handleUserLeftMeeting (payload) {
+    const { meetingId, userId } = payload;
+    const voiceBridge = this._meetings[meetingId];
+
+    if (voiceBridge) {
+      try {
+        await this.mcs.leave(voiceBridge, userId);
+      } catch (e) {
+        Logger.warn(this._logPrefix, "Failed to auto leave room with error", e);
+      }
     }
   }
 

--- a/lib/audio/AudioProcess.js
+++ b/lib/audio/AudioProcess.js
@@ -4,7 +4,7 @@ const AudioManager= require('./AudioManager');
 const BaseProcess = require('../base/BaseProcess');
 const C = require('../bbb/messages/Constants');
 
-const manager = new AudioManager(C.TO_AUDIO, [C.FROM_BBB_MEETING_CHAN], C.AUDIO_MANAGER_PREFIX);
+const manager = new AudioManager(C.TO_AUDIO, [C.FROM_AKKA_APPS], C.AUDIO_MANAGER_PREFIX);
 const newProcess = new BaseProcess(manager, C.AUDIO_PROCESS_PREFIX);
 
 newProcess.start();

--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -96,7 +96,7 @@ module.exports = class Audio extends BaseProvider {
  * @param  {String} connectionId Current connection id at the media manager
  * @return  {Object} user {userId: String, userName: String}
  */
-  getUser(connectionId) {
+  getUser (connectionId) {
     if (this.connectedUsers.hasOwnProperty(connectionId)) {
       return this.connectedUsers[connectionId];
     } else {
@@ -221,7 +221,7 @@ module.exports = class Audio extends BaseProvider {
       Logger.info("[audio] Upstarting source audio for", this.voiceBridge);
       try {
         if (!this.sourceAudioStarted && this.sourceAudioStatus === C.MEDIA_STOPPED) {
-          this.userId = await this.mcs.join(this.voiceBridge, 'SFU', {});
+          this.userId = await this.mcs.join(this.voiceBridge, 'SFU', { name: calleeName });
           Logger.info(LOG_PREFIX, "MCS join for", this.connectionId, "returned", this.userId);
           const options = {
             adapter: 'Freeswitch',
@@ -253,8 +253,9 @@ module.exports = class Audio extends BaseProvider {
     try {
       Logger.info(LOG_PREFIX, "Starting audio instance for", { connectionId, userId, userName }, "at", sessionId, this.sourceAudioStatus, this.sourceAudioStarted);
 
+      const mcsUserId = await this.mcs.join(this.voiceBridge, 'SFU', { userId, name: userName });
       // Storing the user data to be used by the pub calls
-      const user = { userId, userName};
+      const user = { userId, userName, mcsUserId };
       this.addUser(connectionId, user);
 
       const sdpAnswer = await this._subscribeToGlobalAudio(sdpOffer, connectionId);
@@ -270,14 +271,14 @@ module.exports = class Audio extends BaseProvider {
     return new Promise(async (resolve, reject) => {
       try {
         const subscribe = async  () => {
-          const { userId } = this.getUser(connectionId);
+          const { userId, mcsUserId } = this.getUser(connectionId);
           const options = {
             descriptor: sdpOffer,
             adapter: 'Kurento',
             name: this._assembleStreamName('subscribe', userId, this.meetingId),
           }
 
-          const { mediaId, answer } = await this.mcs.subscribe(this.userId,
+          const { mediaId, answer } = await this.mcs.subscribe(mcsUserId,
             this.sourceAudio, C.WEBRTC, options);
 
           this.mcs.onEvent(C.MEDIA_STATE, mediaId, (event) => {
@@ -290,7 +291,7 @@ module.exports = class Audio extends BaseProvider {
 
           this.audioEndpoints[connectionId] = mediaId;
           this._flushCandidatesQueue(connectionId);
-          Logger.info(LOG_PREFIX, "MCS subscribe for user", this.userId, "returned", mediaId);
+          Logger.info(LOG_PREFIX, "MCS subscribe for user", mcsUserId, "returned", mediaId);
           resolve(answer);
         }
 
@@ -301,28 +302,27 @@ module.exports = class Audio extends BaseProvider {
           subscribe();
         }
       } catch (err) {
-        reject(this._handleError(LOG_PREFIX, err, "recv", this.userId));
+        reject(this._handleError(LOG_PREFIX, err, "recv", connectionId));
       }
     });
   }
 
   async stopListener(id) {
     const listener = this.audioEndpoints[id];
-    const userId = this.getUser(id);
+    const  { userId, mcsUserId }  = this.getUser(id);
     Logger.info(LOG_PREFIX, 'Releasing endpoints for', listener);
 
     this.sendUserDisconnectedFromGlobalAudioMessage(id);
 
     if (listener) {
       try {
+        await this.mcs.unsubscribe(mcsUserId, listener);
+
         if (this.audioEndpoints && Object.keys(this.audioEndpoints).length === 1) {
           await this.mcs.leave(this.voiceBridge, this.userId);
           this.sourceAudioStarted = false;
           this.sourceAudioStatus = C.MEDIA_STOPPED;
           this.emit(C.MEDIA_STOPPED, this.voiceBridge);
-        }
-        else {
-          await this.mcs.unsubscribe(this.userId, listener);
         }
 
         delete this.candidatesQueue[id];
@@ -343,6 +343,18 @@ module.exports = class Audio extends BaseProvider {
     try {
       await this.mcs.leave(this.voiceBridge, this.userId);
 
+      for (var connectionId in this.connectedUsers) {
+        const { mcsUserId }  = this.getUser(connectionId);
+        if (mcsUserId) {
+          try {
+            await this.mcs.unsubscribe(mcsUserId, this.audioEndpoints[connectionId]);
+          } catch (e) {
+            Logger.error(this._handleError(e));
+          }
+        }
+        this.sendUserDisconnectedFromGlobalAudioMessage(connectionId);
+      }
+
       for (var listener in this.audioEndpoints) {
         delete this.audioEndpoints[listener];
       }
@@ -351,9 +363,6 @@ module.exports = class Audio extends BaseProvider {
         delete this.candidatesQueue[queue];
       }
 
-      for (var connection in this.connectedUsers) {
-        this.sendUserDisconnectedFromGlobalAudioMessage(connection);
-      }
 
       this.sourceAudioStarted = false;
       this.sourceAudioStatus = C.MEDIA_STOPPED;

--- a/lib/base/MCSAPIWrapper.js
+++ b/lib/base/MCSAPIWrapper.js
@@ -125,8 +125,7 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
 
   async unpublish (user, mediaId) {
     try {
-      await this._mcs.unpublish(mediaId);
-      //await this._mediaController.unpublish(mediaId);
+      await this._mcs.unpublish(user, mediaId);
       return ;
     }
     catch (error) {
@@ -147,7 +146,6 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
   async unsubscribe (user, mediaId) {
     try {
       await this._mcs.unsubscribe(user, mediaId);
-      //await this._mediaController.unsubscribe(user, mediaId);
       return ;
     }
     catch (error) {

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -89,6 +89,7 @@ const config = require('config');
         USER_CAM_BROADCAST_STOPPED_2x: "UserBroadcastCamStopMsg",
         USER_CAM_BROADCAST_STARTED_2x: "UserBroadcastCamStartedEvtMsg",
         PRESENTER_ASSIGNED_2x: "PresenterAssignedEvtMsg",
+        USER_JOINED_VOICE_CONF_MESSAGE_2x: "UserJoinedVoiceConfToClientEvtMsg",
 
         STREAM_IS_RECORDED: "StreamIsRecordedMsg",
 

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -90,6 +90,7 @@ const config = require('config');
         USER_CAM_BROADCAST_STARTED_2x: "UserBroadcastCamStartedEvtMsg",
         PRESENTER_ASSIGNED_2x: "PresenterAssignedEvtMsg",
         USER_JOINED_VOICE_CONF_MESSAGE_2x: "UserJoinedVoiceConfToClientEvtMsg",
+        USER_LEFT_MEETING_2x: "UserLeftMeetingEvtMsg",
 
         STREAM_IS_RECORDED: "StreamIsRecordedMsg",
 

--- a/lib/bbb/pubsub/bbb-gw.js
+++ b/lib/bbb/pubsub/bbb-gw.js
@@ -118,6 +118,11 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
           payload.userId = header.userId;
           this.emit(C.USER_JOINED_VOICE_CONF_MESSAGE_2x, payload);
           break;
+        case C.USER_LEFT_MEETING_2x:
+          payload.meetingId = header.meetingId;
+          payload.userId = header.userId;
+          this.emit(C.USER_LEFT_MEETING_2x, payload);
+          break;
         default:
           this.emit(C.GATEWAY_MESSAGE, msg);
       }

--- a/lib/bbb/pubsub/bbb-gw.js
+++ b/lib/bbb/pubsub/bbb-gw.js
@@ -113,6 +113,11 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
           payload[C.MEETING_ID_2x] = meetingId;
           this.emit(C.PRESENTER_ASSIGNED_2x+meetingId, payload);
           break;
+        case C.USER_JOINED_VOICE_CONF_MESSAGE_2x:
+          payload.meetingId = header.meetingId;
+          payload.userId = header.userId;
+          this.emit(C.USER_JOINED_VOICE_CONF_MESSAGE_2x, payload);
+          break;
         default:
           this.emit(C.GATEWAY_MESSAGE, msg);
       }

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -80,9 +80,9 @@ const MR = class MCSRouter {
   }
 
   async unpublish (args) {
-    const { mediaId } = args;
+    const { userId, mediaId } = args;
     try {
-      await this._mediaController.unpublish(mediaId);
+      await this._mediaController.unpublish(userId, mediaId);
       return ;
     }
     catch (error) {

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -58,17 +58,15 @@ module.exports = class MediaController {
   async join (roomId, type, params) {
     Logger.info(LOG_PREFIX, "Join room => " + roomId + ' as ' + type);
     try {
-      let session;
       const room = await this.createRoom(roomId);
       const user = this.createUser(roomId, type, params);
       room.setUser(user);
-
       Logger.info(LOG_PREFIX, "Resolving user " + user.id);
       return Promise.resolve(user.id);
+    } catch (e) {
+      return Promise.reject(this._handleError(e));
     }
-    catch (err) {
-      return Promise.reject(this._handleError(err));
-    }
+
   }
 
   async leave (roomId, userId) {
@@ -390,8 +388,20 @@ module.exports = class MediaController {
    */
   createUser (roomId, type, params)  {
     Logger.info(LOG_PREFIX, "Creating a new", type, "user at room", roomId);
+    const { userId }  = params;
+    let user;
 
-    const user = new User(roomId, type, params);
+    if (userId) {
+      try {
+        user = this.getUser(userId);
+        return user;
+      } catch (e) {
+        // User was not found, just ignore it and create a new one
+      }
+    }
+
+    // No pre-existing userId sent in the join procedure, create a new one
+    user = new User(roomId, type, params);
     this.users.push(user);
 
     return user;

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -222,6 +222,7 @@ module.exports = class MediaController {
 
   async unpublish (userId, mediaId) {
     try {
+      Logger.info(LOG_PREFIX, "Unpublishing media", mediaId, "of user", userId);
       const user = this.getUser(userId);
       const answer = await user.unpublish(mediaId);
       this.removeMediaSession(mediaId);
@@ -236,6 +237,7 @@ module.exports = class MediaController {
 
   async unsubscribe (userId, mediaId) {
     try {
+      Logger.info(LOG_PREFIX, "Unsubscribing media", mediaId, "of user", userId);
       const user = this.getUser(userId);
       const media = this.getMediaSession(mediaId);
       const answer = await user.unsubscribe(mediaId);

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -17,7 +17,7 @@ const LOG_PREFIX = "[mcs-user]";
 
 module.exports = class User {
   constructor(roomId, type, params = {}) {
-    this.id = rid();
+    this.id = params.userId? params.userId : rid();
     this.roomId = roomId;
     this.type = type;
     this.name = params.name ? params.name : this.id;

--- a/lib/screenshare/ScreenshareManager.js
+++ b/lib/screenshare/ScreenshareManager.js
@@ -54,7 +54,6 @@ module.exports = class ScreenshareManager extends BaseManager {
 
         // starts screenshare peer with role by sending sessionID, websocket and sdpoffer
         try {
-          console.log("OWA START", userName);
           const sdpAnswer = await session.start(voiceBridge, connectionId, sdpOffer, callerName, role, userName)
           Logger.debug(this._logPrefix, "Started peer", voiceBridge, " for connection", connectionId, "with SDP answer", sdpAnswer);
 

--- a/lib/screenshare/ScreenshareManager.js
+++ b/lib/screenshare/ScreenshareManager.js
@@ -82,7 +82,7 @@ module.exports = class ScreenshareManager extends BaseManager {
           if (role === C.SEND_ROLE) {
             this._bbbGW.once(C.PRESENTER_ASSIGNED_2x+message.internalMeetingId, async (payload) => {
               Logger.info(this._logPrefix, "Presenter changed, forcibly closing screensharing session at", message.internalMeetingId);
-              await this.closeSession(session, connectionId, role, voiceBridge, callerName);
+              await this.closeSession(session, connectionId, role, voiceBridge);
               this._bbbGW.publish(JSON.stringify({
                 connectionId: connectionId,
                 type: C.SCREENSHARE_APP,
@@ -122,7 +122,7 @@ module.exports = class ScreenshareManager extends BaseManager {
 
       case 'close':
         Logger.info(this._logPrefix, 'Connection ' + connectionId + ' closed');
-        this.closeSession(session, connectionId, role, voiceBridge, callerName);
+        this.closeSession(session, connectionId, role, voiceBridge);
         break;
 
       default:
@@ -162,7 +162,7 @@ module.exports = class ScreenshareManager extends BaseManager {
     }
   }
 
-  async closeSession (session, connectionId, role, sessionId, userId) {
+  async closeSession (session, connectionId, role, sessionId) {
     if (session && session.constructor == Screenshare) {
       if (role === C.SEND_ROLE && session) {
         Logger.info(this._logPrefix, "Stopping presenter " + sessionId);
@@ -170,8 +170,8 @@ module.exports = class ScreenshareManager extends BaseManager {
         return;
       }
       if (role === C.RECV_ROLE && session) {
-        Logger.info(this._logPrefix, "Stopping viewer " + sessionId);
-        await session.stopViewer(connectionId, userId);
+        Logger.info(this._logPrefix, "Stopping viewer ", sessionId);
+        await session.stopViewer(connectionId);
       }
     }
   }

--- a/lib/screenshare/ScreenshareManager.js
+++ b/lib/screenshare/ScreenshareManager.js
@@ -81,7 +81,7 @@ module.exports = class ScreenshareManager extends BaseManager {
           if (role === C.SEND_ROLE) {
             this._bbbGW.once(C.PRESENTER_ASSIGNED_2x+message.internalMeetingId, async (payload) => {
               Logger.info(this._logPrefix, "Presenter changed, forcibly closing screensharing session at", message.internalMeetingId);
-              await this.closeSession(session, connectionId, role, voiceBridge);
+              await this.closeSession(session, connectionId, role, voiceBridge, callerName);
               this._bbbGW.publish(JSON.stringify({
                 connectionId: connectionId,
                 type: C.SCREENSHARE_APP,
@@ -121,7 +121,7 @@ module.exports = class ScreenshareManager extends BaseManager {
 
       case 'close':
         Logger.info(this._logPrefix, 'Connection ' + connectionId + ' closed');
-        this.closeSession(session, connectionId, role, voiceBridge);
+        this.closeSession(session, connectionId, role, voiceBridge, callerName);
         break;
 
       default:
@@ -161,7 +161,7 @@ module.exports = class ScreenshareManager extends BaseManager {
     }
   }
 
-  async closeSession (session, connectionId, role, sessionId) {
+  async closeSession (session, connectionId, role, sessionId, userId) {
     if (session && session.constructor == Screenshare) {
       if (role === C.SEND_ROLE && session) {
         Logger.info(this._logPrefix, "Stopping presenter " + sessionId);
@@ -170,7 +170,7 @@ module.exports = class ScreenshareManager extends BaseManager {
       }
       if (role === C.RECV_ROLE && session) {
         Logger.info(this._logPrefix, "Stopping viewer " + sessionId);
-        await session.stopViewer(connectionId);
+        await session.stopViewer(connectionId, userId);
       }
     }
   }

--- a/lib/screenshare/ScreenshareManager.js
+++ b/lib/screenshare/ScreenshareManager.js
@@ -33,7 +33,8 @@ module.exports = class ScreenshareManager extends BaseManager {
       connectionId,
       role,
       sdpOffer,
-      callerName
+      callerName,
+      userName
     } = message;
 
     let iceQueue, session;
@@ -44,7 +45,7 @@ module.exports = class ScreenshareManager extends BaseManager {
     switch (message.id) {
       case 'start':
         if (!session) {
-          const { vh, vw, internalMeetingId} = message;
+          const { vh, vw, internalMeetingId } = message;
           session = new Screenshare(connectionId, this._bbbGW,
             voiceBridge, connectionId, vh, vw,
             internalMeetingId, this.mcs);
@@ -53,7 +54,8 @@ module.exports = class ScreenshareManager extends BaseManager {
 
         // starts screenshare peer with role by sending sessionID, websocket and sdpoffer
         try {
-          const sdpAnswer = await session.start(voiceBridge, connectionId, sdpOffer, callerName, role)
+          console.log("OWA START", userName);
+          const sdpAnswer = await session.start(voiceBridge, connectionId, sdpOffer, callerName, role, userName)
           Logger.debug(this._logPrefix, "Started peer", voiceBridge, " for connection", connectionId, "with SDP answer", sdpAnswer);
 
           // Empty ice queue after starting session

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -224,43 +224,43 @@ module.exports = class Screenshare extends BaseProvider {
     });
   }
 
-  start (sessionId, connectionId, sdpOffer, userId, role) {
+  start (sessionId, connectionId, sdpOffer, bbbUserId, role, bbbUserName) {
     return new Promise(async (resolve, reject) => {
       this._status = C.MEDIA_STARTING;
       // Probe akka-apps to see if this is to be recorded
       if (SHOULD_RECORD && role === C.SEND_ROLE) {
-        this.isRecorded = await this.probeForRecordingStatus(this._meetingId, userId);
+        this.isRecorded = await this.probeForRecordingStatus(this._meetingId, bbbUserId);
       }
 
       Logger.info(LOG_PREFIX, "Starting session", this._voiceBridge + '-' + role);
 
       if (role === C.RECV_ROLE) {
         try {
-          const sdpAnswer = await this._startViewer(connectionId, this._voiceBridge, sdpOffer, userId, this._presenterEndpoint)
+          const sdpAnswer = await this._startViewer(connectionId, this._voiceBridge, sdpOffer, bbbUserId, this._presenterEndpoint, bbbUserName)
           return resolve(sdpAnswer);
         }
         catch (err) {
-          return reject(this._handleError(LOG_PREFIX, err, role, userId));
+          return reject(this._handleError(LOG_PREFIX, err, role, bbbUserId));
         }
       }
 
       if (role === C.SEND_ROLE) {
         try {
-          const sdpAnswer = await this._startPresenter(sdpOffer, userId);
+          const sdpAnswer = await this._startPresenter(sdpOffer, bbbUserId, bbbUserName);
           return resolve(sdpAnswer);
         }
         catch (err) {
-          return reject(this._handleError(LOG_PREFIX, err, role, userId));
+          return reject(this._handleError(LOG_PREFIX, err, role, bbbUserId));
         }
       }
     });
   }
 
-  _startPresenter (sdpOffer, userId) {
+  _startPresenter (sdpOffer, userId, bbbUserName) {
     return new Promise(async (resolve, reject) => {
       try {
         try {
-          this.presenterMCSUserId = await this.mcs.join(this._voiceBridge, 'SFU', { userId });
+          this.presenterMCSUserId = await this.mcs.join(this._voiceBridge, 'SFU', { userId, name: bbbUserName });
           Logger.info(LOG_PREFIX, "MCS Join for", this._connectionId, "returned", this.presenterMCSUserId);
         }
         catch (error) {
@@ -365,14 +365,14 @@ module.exports = class Screenshare extends BaseProvider {
     }
   }
 
-  _startViewer(connectionId, voiceBridge, sdpOffer, userId, presenterEndpoint) {
+  _startViewer(connectionId, voiceBridge, sdpOffer, userId, presenterEndpoint, bbbUserName) {
     return new Promise(async (resolve, reject) => {
       Logger.info(LOG_PREFIX, "Starting viewer", userId, "for voiceBridge", this._voiceBridge);
       let sdpAnswer, mcsUserId;
 
       this._viewersCandidatesQueue[connectionId] = [];
       try {
-        this._viewerUsers[userId] = await this.mcs.join(this._voiceBridge, 'SFU', { userId });
+        this._viewerUsers[userId] = await this.mcs.join(this._voiceBridge, 'SFU', { userId, name: bbbUserName });
         mcsUserId = this._viewerUsers[userId];
         Logger.info(LOG_PREFIX, "MCS Join for", connectionId, "returned", mcsUserId);
       }

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -40,7 +40,7 @@ module.exports = class Screenshare extends BaseProvider {
     this._vw = vw;
     this._vh = vh;
     this._presenterCandidatesQueue = [];
-    this._viewerUsers = [];
+    this._viewerUsers = {};
     this._viewerEndpoints = [];
     this._viewersCandidatesQueue = [];
     this._status = C.MEDIA_STOPPED;
@@ -372,8 +372,8 @@ module.exports = class Screenshare extends BaseProvider {
 
       this._viewersCandidatesQueue[connectionId] = [];
       try {
-        this._viewerUsers[userId] = await this.mcs.join(this._voiceBridge, 'SFU', { userId, name: bbbUserName });
-        mcsUserId = this._viewerUsers[userId];
+        mcsUserId = await this.mcs.join(this._voiceBridge, 'SFU', { userId, name: bbbUserName });
+        this._viewerUsers[userId] = { userId, connectionId };
         Logger.info(LOG_PREFIX, "MCS Join for", connectionId, "returned", mcsUserId);
       }
       catch (error) {
@@ -443,6 +443,12 @@ module.exports = class Screenshare extends BaseProvider {
         await this.mcs.releaseContentFloor(this._voiceBridge, this._presenterEndpoint);
         await this.mcs.unpublish(this.presenterMCSUserId, this._presenterEndpoint);
         await this.mcs.unsubscribe(this.presenterMCSUserId, this._ffmpegEndpoint);
+
+        Object.keys(this._viewerUsers).forEach(async vuk => {
+          const { connectionId } = this._viewerUsers[vuk];
+          this.stopViewer(connectionId);
+        });
+
         Logger.info(LOG_PREFIX, "Left MCS room", this._voiceBridge);
         delete sources[this._presenterEndpoint];
         this._candidatesQueue = null;
@@ -562,14 +568,21 @@ module.exports = class Screenshare extends BaseProvider {
     Logger.warn(LOG_PREFIX, "TODO RTP NOT_FLOWING");
   }
 
-  async stopViewer(id, userId) {
-    const mcsUser = this._viewerUsers[userId];
-    let viewer = this._viewerEndpoints[id];
-    Logger.info(LOG_PREFIX, 'Releasing endpoints for', mcsUser, 'from', this._presenterEndpoint);
+  async stopViewer(id) {
+    const vuKey = Object.keys(this._viewerUsers).find(vuk => this._viewerUsers[vuk].connectionId === id);
+
+    if (vuKey == null) {
+      return;
+    }
+
+    const { userId } = this._viewerUsers[vuKey];
+    const viewer = this._viewerEndpoints[id];
+
+    Logger.info(LOG_PREFIX, 'Releasing endpoints for', userId, 'from', this._presenterEndpoint);
 
     if (viewer) {
       try {
-        await this.mcs.unsubscribe(mcsUser, viewer);
+        await this.mcs.unsubscribe(userId, viewer);
         this._viewersCandidatesQueue[id] = null;
         this._viewerEndpoints[id] = null;
         return;
@@ -577,7 +590,6 @@ module.exports = class Screenshare extends BaseProvider {
       catch (err) {
         this._handleError(LOG_PREFIX, err);
         Logger.error(LOG_PREFIX, 'MCS returned error when trying to unsubscribe', err);
-        return;
       }
     }
   }

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -48,6 +48,23 @@ module.exports = class Screenshare extends BaseProvider {
     this.recording = {};
     this.isRecorded = false;
     this._recordingSubPath = 'screenshare';
+    this._trackUserEvents();
+  }
+
+  _trackUserEvents () {
+    this.bbbGW.on(C.USER_LEFT_MEETING_2x, this._handleUserLeftMeeting.bind(this));
+  }
+
+  async _handleUserLeftMeeting (payload) {
+    const { meetingId, userId } = payload;
+
+    if (this._viewerUsers[userId] || this.presenterMCSUserId === userId) {
+      try {
+        await this.mcs.leave(this._voiceBridge, userId);
+      } catch (e) {
+        Logger.warn(LOG_PREFIX, "Failed to auto leave room with error", e);
+      }
+    }
   }
 
   async onIceCandidate (candidate, role, userId, connectionId) {
@@ -548,7 +565,7 @@ module.exports = class Screenshare extends BaseProvider {
   async stopViewer(id, userId) {
     const mcsUser = this._viewerUsers[userId];
     let viewer = this._viewerEndpoints[id];
-    Logger.info(LOG_PREFIX, 'Releasing endpoints for', viewer, 'from', this._presenterEndpoint);
+    Logger.info(LOG_PREFIX, 'Releasing endpoints for', mcsUser, 'from', this._presenterEndpoint);
 
     if (viewer) {
       try {

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -29,7 +29,7 @@ module.exports = class Screenshare extends BaseProvider {
     super(bbbGW);
     this.sfuApp = C.SCREENSHARE_APP;
     this.mcs = mcs;
-    this.mcsUserId;
+    this.presenterMCSUserId;
     this.userId = userId;
     this._connectionId = id;
     this._presenterEndpoint = null;
@@ -40,6 +40,7 @@ module.exports = class Screenshare extends BaseProvider {
     this._vw = vw;
     this._vh = vh;
     this._presenterCandidatesQueue = [];
+    this._viewerUsers = [];
     this._viewerEndpoints = [];
     this._viewersCandidatesQueue = [];
     this._status = C.MEDIA_STOPPED;
@@ -179,7 +180,7 @@ module.exports = class Screenshare extends BaseProvider {
     return new Promise(async (resolve, reject) => {
       try {
         const recordingPath = this.getRecordingPath(this._meetingId, this._recordingSubPath, this._voiceBridge);
-        const recordingId = await this.mcs.startRecording(this.mcsUserId, this._presenterEndpoint, recordingPath);
+        const recordingId = await this.mcs.startRecording(this.presenterMCSUserId, this._presenterEndpoint, recordingPath);
         this.recording = { recordingId, filename: recordingPath };
         this.mcs.onEvent(C.MEDIA_STATE, this.recording.recordingId, (event) => {
           this._recordingState(event, this.recording.recordingId);
@@ -215,17 +216,6 @@ module.exports = class Screenshare extends BaseProvider {
       }
 
       Logger.info(LOG_PREFIX, "Starting session", this._voiceBridge + '-' + role);
-      if (!this.mcsUserId) {
-        try {
-          this.mcsUserId = await this.mcs.join(this._voiceBridge, 'SFU', {});
-          Logger.info(LOG_PREFIX, "MCS Join for", this._connectionId, "returned", this.mcsUserId);
-
-        }
-        catch (error) {
-          Logger.error(LOG_PREFIX, "MCS Join returned error =>", error);
-          return reject(this._handleError(LOG_PREFIX, error, role, userId));
-        }
-      }
 
       if (role === C.RECV_ROLE) {
         try {
@@ -239,7 +229,7 @@ module.exports = class Screenshare extends BaseProvider {
 
       if (role === C.SEND_ROLE) {
         try {
-          const sdpAnswer = await this._startPresenter(sdpOffer);
+          const sdpAnswer = await this._startPresenter(sdpOffer, userId);
           return resolve(sdpAnswer);
         }
         catch (err) {
@@ -249,9 +239,18 @@ module.exports = class Screenshare extends BaseProvider {
     });
   }
 
-  _startPresenter (sdpOffer) {
+  _startPresenter (sdpOffer, userId) {
     return new Promise(async (resolve, reject) => {
       try {
+        try {
+          this.presenterMCSUserId = await this.mcs.join(this._voiceBridge, 'SFU', { userId });
+          Logger.info(LOG_PREFIX, "MCS Join for", this._connectionId, "returned", this.presenterMCSUserId);
+        }
+        catch (error) {
+          Logger.error(LOG_PREFIX, "MCS Join returned error =>", error);
+          return reject(this._handleError(LOG_PREFIX, error, role, userId));
+        }
+
         const presenterSdpAnswer = await this._publishWebRTCStream(sdpOffer);
         await this.mcs.setContentFloor(this._voiceBridge, this._presenterEndpoint);
 
@@ -278,7 +277,7 @@ module.exports = class Screenshare extends BaseProvider {
         mediaProfile: 'content',
       };
 
-      const { mediaId, answer } = await this.mcs.publish(this.mcsUserId, this._voiceBridge, C.WEBRTC, options);
+      const { mediaId, answer } = await this.mcs.publish(this.presenterMCSUserId, this._voiceBridge, C.WEBRTC, options);
       this._presenterEndpoint = mediaId;
 
       this.mcs.onEvent(C.MEDIA_STATE, this._presenterEndpoint, (event) => {
@@ -294,7 +293,7 @@ module.exports = class Screenshare extends BaseProvider {
       this.flushCandidatesQueue(this.mcs, [...this._presenterCandidatesQueue], this._presenterEndpoint);
       this._presenterCandidatesQueue = [];
 
-      Logger.info(LOG_PREFIX, "MCS publish for user", this.mcsUserId, "returned", this._presenterEndpoint);
+      Logger.info(LOG_PREFIX, "MCS publish for user", this.presenterMCSUserId, "returned", this._presenterEndpoint);
       return presenterSdpAnswer;
     }
     catch (err) {
@@ -327,7 +326,7 @@ module.exports = class Screenshare extends BaseProvider {
         this._presenterEndpoint = await this._fetchContentFloor();;
       }
 
-      const { mediaId, answer } = await this.mcs.subscribe(this.mcsUserId,
+      const { mediaId, answer } = await this.mcs.subscribe(this.presenterMCSUserId,
         this._presenterEndpoint, C.RTP, options);
 
       this._ffmpegEndpoint = mediaId;
@@ -343,7 +342,7 @@ module.exports = class Screenshare extends BaseProvider {
         this._mediaStateRTP(event, this._ffmpegEndpoint);
       });
 
-      Logger.info(LOG_PREFIX, "MCS subscribe for user", this.mcsUserId, "returned", this._ffmpegEndpoint);
+      Logger.info(LOG_PREFIX, "MCS subscribe for user", this.presenterMCSUserId, "returned", this._ffmpegEndpoint);
     } catch (err) {
       throw err;
     }
@@ -352,9 +351,19 @@ module.exports = class Screenshare extends BaseProvider {
   _startViewer(connectionId, voiceBridge, sdpOffer, userId, presenterEndpoint) {
     return new Promise(async (resolve, reject) => {
       Logger.info(LOG_PREFIX, "Starting viewer", userId, "for voiceBridge", this._voiceBridge);
-      let sdpAnswer;
+      let sdpAnswer, mcsUserId;
 
       this._viewersCandidatesQueue[connectionId] = [];
+      try {
+        this._viewerUsers[userId] = await this.mcs.join(this._voiceBridge, 'SFU', { userId });
+        mcsUserId = this._viewerUsers[userId];
+        Logger.info(LOG_PREFIX, "MCS Join for", connectionId, "returned", mcsUserId);
+      }
+      catch (error) {
+        Logger.error(LOG_PREFIX, "MCS Join returned error =>", error);
+        return reject(this._handleError(LOG_PREFIX, error, role, userId));
+      }
+
 
       try {
         const options = {
@@ -367,7 +376,7 @@ module.exports = class Screenshare extends BaseProvider {
           this._presenterEndpoint = await this._fetchContentFloor();
         }
 
-        const { mediaId, answer } = await this.mcs.subscribe(this.mcsUserId,
+        const { mediaId, answer } = await this.mcs.subscribe(mcsUserId,
           this._presenterEndpoint, C.WEBRTC, options);
 
         this._viewerEndpoints[connectionId] = mediaId;
@@ -384,7 +393,7 @@ module.exports = class Screenshare extends BaseProvider {
           this._onMCSIceCandidate(event, connectionId, mediaId);
         });
 
-        Logger.info(LOG_PREFIX, "MCS subscribe returned for user", this.mcsUserId, "returned", this._viewerEndpoints[connectionId], "at userId", userId);
+        Logger.info(LOG_PREFIX, "MCS subscribe returned for user", mcsUserId, "returned", this._viewerEndpoints[connectionId], "at userId", userId);
         return resolve(sdpAnswer);
       }
       catch (err) {
@@ -397,7 +406,7 @@ module.exports = class Screenshare extends BaseProvider {
   async stopRecording() {
     this.sendStopShareEvent();
 
-    this.mcs.stopRecording(this.mcsUserId, this.recording.recordingId);
+    this.mcs.stopRecording(this.presenterMCSUserId, this.recording.recordingId);
   }
 
   stop () {
@@ -406,7 +415,7 @@ module.exports = class Screenshare extends BaseProvider {
         if (this._status === C.MEDIA_STOPPED) {
           return resolve();
         }
-        Logger.info('[screnshare] Stopping and releasing endpoints for MCS user', this.mcsUserId);
+        Logger.info('[screnshare] Stopping and releasing endpoints for MCS user', this.presenterMCSUserId);
         await this._stopScreensharing();
         if (this.isRecorded) {
           await this.stopRecording();
@@ -414,8 +423,9 @@ module.exports = class Screenshare extends BaseProvider {
 
         this._status = C.MEDIA_STOPPED;
 
-        this.mcs.releaseContentFloor(this._voiceBridge, this._presenterEndpoint);
-        await this.mcs.leave(this._voiceBridge, this.mcsUserId);
+        await this.mcs.releaseContentFloor(this._voiceBridge, this._presenterEndpoint);
+        await this.mcs.unpublish(this.presenterMCSUserId, this._presenterEndpoint);
+        await this.mcs.unsubscribe(this.presenterMCSUserId, this._ffmpegEndpoint);
         Logger.info(LOG_PREFIX, "Left MCS room", this._voiceBridge);
         delete sources[this._presenterEndpoint];
         this._candidatesQueue = null;
@@ -535,13 +545,14 @@ module.exports = class Screenshare extends BaseProvider {
     Logger.warn(LOG_PREFIX, "TODO RTP NOT_FLOWING");
   }
 
-  async stopViewer(id) {
+  async stopViewer(id, userId) {
+    const mcsUser = this._viewerUsers[userId];
     let viewer = this._viewerEndpoints[id];
     Logger.info(LOG_PREFIX, 'Releasing endpoints for', viewer, 'from', this._presenterEndpoint);
 
     if (viewer) {
       try {
-        await this.mcs.unsubscribe(this.mcsUserId, viewer);
+        await this.mcs.unsubscribe(mcsUser, viewer);
         this._viewersCandidatesQueue[id] = null;
         this._viewerEndpoints[id] = null;
         return;

--- a/lib/video/VideoManager.js
+++ b/lib/video/VideoManager.js
@@ -74,14 +74,14 @@ module.exports = class VideoManager extends BaseManager {
       case 'start':
         Logger.info(this._logPrefix, 'Received message [' + message.id + '] from connection ' + sessionId);
 
-        const { userId } = message;
+        const { userId, userName } = message;
 
         if (video) {
           if (video.status !== C.MEDIA_STARTING) {
             await this._stopSession(sessionId);
             const { voiceBridge } = message;
             video = new Video(this._bbbGW, message.meetingId, message.cameraId,
-              shared, message.connectionId, this.mcs, voiceBridge, userId);
+              shared, message.connectionId, this.mcs, voiceBridge, userId, userName);
             this._sessions[sessionId] = video;
           } else {
            return;
@@ -89,7 +89,7 @@ module.exports = class VideoManager extends BaseManager {
         } else {
           const { voiceBridge } = message;
           video = new Video(this._bbbGW, message.meetingId, message.cameraId,
-            shared, message.connectionId, this.mcs, voiceBridge, userId);
+            shared, message.connectionId, this.mcs, voiceBridge, userId, userName);
           this._sessions[sessionId] = video;
         }
 

--- a/lib/video/VideoManager.js
+++ b/lib/video/VideoManager.js
@@ -74,12 +74,14 @@ module.exports = class VideoManager extends BaseManager {
       case 'start':
         Logger.info(this._logPrefix, 'Received message [' + message.id + '] from connection ' + sessionId);
 
+        const { userId } = message;
+
         if (video) {
           if (video.status !== C.MEDIA_STARTING) {
             await this._stopSession(sessionId);
             const { voiceBridge } = message;
             video = new Video(this._bbbGW, message.meetingId, message.cameraId,
-              shared, message.connectionId, this.mcs, voiceBridge);
+              shared, message.connectionId, this.mcs, voiceBridge, userId);
             this._sessions[sessionId] = video;
           } else {
            return;
@@ -87,7 +89,7 @@ module.exports = class VideoManager extends BaseManager {
         } else {
           const { voiceBridge } = message;
           video = new Video(this._bbbGW, message.meetingId, message.cameraId,
-            shared, message.connectionId, this.mcs, voiceBridge);
+            shared, message.connectionId, this.mcs, voiceBridge, userId);
           this._sessions[sessionId] = video;
         }
 
@@ -120,26 +122,6 @@ module.exports = class VideoManager extends BaseManager {
             ...errorMessage
           }), C.FROM_VIDEO);
         }
-        break;
-
-      case 'publish':
-        Logger.info("Received SUBSCRIBE from external source", message);
-
-        const userId = await this.mcs.join(message.meetingId, 'SFU', {});
-
-        const retRtp = await this.mcs.publish(userId, message.meetingId, C.RTP, { descriptor: message.sdpOffer });
-
-        Video.setSharedWebcam(cameraId.split('-')[0], retRtp.sessionId);
-
-        this._bbbGW.publish(JSON.stringify({
-          id: 'publish',
-          type: C.VIDEO_APP,
-          role: 'send',
-          response: 'accepted',
-          meetingId: message.meetingId,
-          sessionId: retRtp.sessionId,
-          answer: retRtp.answer
-        }), C.FROM_VIDEO);
         break;
 
       case 'stop':

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -13,12 +13,13 @@ const errors = require('../base/errors');
 let sources = {};
 
 module.exports = class Video extends BaseProvider {
-  constructor(bbbGW, _meetingId, _id, _shared, _connectionId, mcs, voiceBridge, bbbUserId) {
+  constructor(bbbGW, _meetingId, _id, _shared, _connectionId, mcs, voiceBridge, bbbUserId, bbbUserName) {
     super(bbbGW);
     this.sfuApp = C.VIDEO_APP;
     this.mcs = mcs;
     this.id = _id;
     this.bbbUserId = bbbUserId;
+    this.bbbUserName = bbbUserName;
     this.connectionId = _connectionId;
     this.meetingId = _meetingId;
     this.voiceBridge = voiceBridge;
@@ -35,6 +36,23 @@ module.exports = class Video extends BaseProvider {
     this.notFlowingTimeout = null;
     this.isRecording = false;
     this.pending = false;
+    this._trackUserEvents();
+  }
+
+  _trackUserEvents () {
+    this.bbbGW.on(C.USER_LEFT_MEETING_2x, this._handleUserLeftMeeting.bind(this));
+  }
+
+  async _handleUserLeftMeeting (payload) {
+    const { meetingId, userId } = payload;
+
+    if (this.bbbUserId === userId) {
+      try {
+        await this.mcs.leave(this.voiceBridge, this.userId);
+      } catch (e) {
+        Logger.warn(LOG_PREFIX, "Failed to auto leave room with error", e);
+      }
+    }
   }
 
   static setSource (userId, stream) {
@@ -228,9 +246,9 @@ module.exports = class Video extends BaseProvider {
             this.isRecorded = await this.probeForRecordingStatus(this.meetingId, this.id);
           }
 
-          this.userId = await this.mcs.join(this.voiceBridge, 'SFU', { userId: this.bbbUserId });
+          this.userId = await this.mcs.join(this.voiceBridge, 'SFU', { userId: this.bbbUserId, name: this.bbbUserName });
           this.mediaUserJoined(this.streamName);
-          Logger.info(LOG_PREFIX, "MCS join for", this.streamName, "returned", this.userId);
+          Logger.info(LOG_PREFIX, "MCS join for", this.bbbUserId, this.bbbUserName, "returned", this.userId);
           const sdpAnswer = await this._addMCSMedia(C.WEBRTC, sdpOffer);
 
           this.mcs.onEvent(C.MEDIA_STATE, this.mediaId, (event) => {

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -13,11 +13,12 @@ const errors = require('../base/errors');
 let sources = {};
 
 module.exports = class Video extends BaseProvider {
-  constructor(bbbGW, _meetingId, _id, _shared, _connectionId, mcs, voiceBridge) {
+  constructor(bbbGW, _meetingId, _id, _shared, _connectionId, mcs, voiceBridge, bbbUserId) {
     super(bbbGW);
     this.sfuApp = C.VIDEO_APP;
     this.mcs = mcs;
     this.id = _id;
+    this.bbbUserId = bbbUserId;
     this.connectionId = _connectionId;
     this.meetingId = _meetingId;
     this.voiceBridge = voiceBridge;
@@ -227,7 +228,7 @@ module.exports = class Video extends BaseProvider {
             this.isRecorded = await this.probeForRecordingStatus(this.meetingId, this.id);
           }
 
-          this.userId = await this.mcs.join(this.voiceBridge, 'SFU', {});
+          this.userId = await this.mcs.join(this.voiceBridge, 'SFU', { userId: this.bbbUserId });
           this.mediaUserJoined(this.streamName);
           Logger.info(LOG_PREFIX, "MCS join for", this.streamName, "returned", this.userId);
           const sdpAnswer = await this._addMCSMedia(C.WEBRTC, sdpOffer);
@@ -374,10 +375,12 @@ module.exports = class Video extends BaseProvider {
           try {
             this.status = C.MEDIA_STOPPING;
 
-            await this.mcs.leave(this.voiceBridge, this.userId);
 
             if (this.shared) {
+              await this.mcs.unpublish(this.userId, this.mediaId);
               delete sources[this.id];
+            } else {
+              await this.mcs.unsubscribe(this.userId, this.mediaId);
             }
 
             if (this.notFlowingTimeout) {


### PR DESCRIPTION
- BBB and MCS users now have a 1:1 ratio
- Users are automatically started when a BBB user first uses any of the media functionalities (audio, video, screenshare or listen only)
- Users are ejected when the BBB users leaves
- Map the BBB user's name to the MCS user
- Map the BBB user's `intId` to the MCS user's `userId`
- Fixed the `unpublish` API method implementation
