### PR TITLE
Closing v2.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/*
 *swo
 *swp
 *~
+*log

--- a/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
+++ b/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
@@ -82,28 +82,36 @@ module.exports = class Freeswitch extends EventEmitter {
   async connect (sourceId, sinkId, type) {
     const userAgent = this._userAgents[sourceId];
     const { voiceBridge, session } = userAgent;
-    const rtpConverter = this._rtpConverters[sourceId].elementId;
+    const rtpConverter = this._rtpConverters[sourceId];
 
-    Logger.debug("[mcs-media-freeswitch] Connecting", rtpConverter, "to", sinkId);
+    Logger.debug("[mcs-media-freeswitch] Connecting", sourceId, "to", sinkId);
 
     if (session) {
-      return new Promise((resolve, reject) => {
+      return new Promise(async (resolve, reject) => {
+        if (rtpConverter == null) {
+          return reject(C.ERROR.MEDIA_NOT_FOUND);
+        }
+
         switch (type) {
           case C.CONNECTION_TYPE.ALL:
 
           case C.CONNECTION_TYPE.AUDIO:
 
           case C.CONNECTION_TYPE.VIDEO:
-            this._Kurento.connect(rtpConverter, sinkId, type);
-            return resolve();
+            try {
+              await this._Kurento.connect(rtpConverter.elementId, sinkId, type);
+              return resolve();
+            } catch (e) {
+              return reject(e);
+            }
             break;
-
-          default: return reject("[mcs-media] Invalid connect type");
+          default:
+            return reject(C.ERROR.MEDIA_INVALID_OPERATION);
         }
       });
     }
     else {
-      return Promise.reject("[mcs-media] Failed to connect " + type + ": " + sourceId + " to " + sinkId);
+      return Promise.reject(C.ERROR.MEDIA_NOT_FOUND);
     }
   }
 

--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -125,6 +125,8 @@ module.exports = class Kurento extends EventEmitter {
             delete this._mediaPipelines[room][hostId];
             return resolve()
           });
+        } else {
+          return resolve();
         }
       }
       catch (error) {
@@ -569,8 +571,13 @@ module.exports = class Kurento extends EventEmitter {
                   await this._releasePipeline(room, hostId);
                 }
               }
+
               return resolve();
             });
+          } else {
+            // Element is not available for release anymore, so it's pipeline
+            // was probably already released altogether. Just resolve the call.
+            return resolve();
           }
         }
         else {

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -724,7 +724,7 @@ const MR = class MCSRouter {
     this.emitter.on(C.EVENT.ROOM_CREATED, roomId => {
       const clients = this._getClientToDispatch('all', C.EVENT.ROOM_CREATED);
 
-      Logger.trace('[mcs-router] Room created event', roomId, typeof client);
+      Logger.trace('[mcs-router] Room created event', roomId);
 
       if (clients.length > 0) {
         clients.forEach(client => {
@@ -736,7 +736,7 @@ const MR = class MCSRouter {
     this.emitter.on(C.EVENT.ROOM_DESTROYED, roomId => {
       const clients = this._getClientToDispatch(roomId, C.EVENT.ROOM_DESTROYED);
 
-      Logger.trace('[mcs-router] Room destroyed event', roomId, typeof client);
+      Logger.trace('[mcs-router] Room destroyed event', roomId);
 
       this._removeFromClientEventMap(roomId, C.EVENT.MEDIA_CONNECTED);
       this._removeFromClientEventMap(roomId, C.EVENT.USER_JOINED);

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -207,10 +207,8 @@ module.exports = class MediaController {
           case C.MEDIA_TYPE.URI:
             const  { session, answer } = await user.subscribe(params.descriptor, type, source, params);
             this.addMediaSession(session);
-            //source.subscribedSessions.push(session.id);
             resolve({descriptor: answer, mediaId: session.id});
             session.sessionStarted();
-            Logger.trace(LOG_PREFIX, "Updated", source.id,  "subscribers list to", source.subscribedSessions);
             break;
           default:
             return reject(this._handleError(C.ERROR.MEDIA_INVALID_TYPE));
@@ -259,7 +257,6 @@ module.exports = class MediaController {
 
         const { recordingSession, answer } = await user.startRecording(recordingPath, C.MEDIA_TYPE.RECORDING, sourceSession, params);
 
-        sourceSession.subscribedSessions.push(recordingSession.id);
         this.addMediaSession(recordingSession);
 
         resolve(answer);

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -57,6 +57,7 @@ module.exports = class MediaSession {
     this.audioMediaElement;
     // Array of media sessions that are subscribed to this feed
     this.subscribedSessions = [];
+    this.medias = [];
     // An object that describes the capabilities of this media session
     this.mediaTypes = {
       video: false,
@@ -70,7 +71,6 @@ module.exports = class MediaSession {
     this._mediaProfile = options.mediaProfile? options.mediaProfile : 'main';
     // Media specs for the media. If not specified, falls back to the default
     this.mediaSpecs = options.mediaSpecs? options.mediaSpecs : MEDIA_SPECS;
-
     this.muted = false;
     this.volume = 50;
   }

--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -165,7 +165,7 @@ module.exports = class Media {
 
     Logger.trace(LOG_PREFIX, "Adapter elements to be connected", this.adapterElementId, "=>", connSink.adapterElementId);
     try {
-      this.adapter.connect(
+      await this.adapter.connect(
         this.adapterElementId,
         connSink.adapterElementId,
         connectionType,
@@ -177,7 +177,7 @@ module.exports = class Media {
       // Temporarily supress connect error throw until we fix
       // the mediaProfile spec
       //throw (this._handleError(err));
-      Logger.error(LOG_PREFIX, err);
+      this._handleError(err);
     }
   }
 
@@ -279,7 +279,7 @@ module.exports = class Media {
     else {
       // TODO mediaId could be this.id?
       event = { mediaSessionId: this.mediaSessionId, mediaId: this.mediaSessionId, ...event };
-      Logger.trace("[mcs-media-session] Dispatching", event);
+      Logger.info("[mcs-media-session] Media", this.id, "media state event", event);
       GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_STATE.MEDIA_EVENT, event);
     }
   }

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -25,7 +25,6 @@ module.exports = class SDPSession extends MediaSession {
     options
   ) {
     super(room, user, type, options);
-    this.medias = [];
     // {SdpWrapper} SdpWrapper
     this._offer;
     this._answer;
@@ -57,14 +56,22 @@ module.exports = class SDPSession extends MediaSession {
       audioAdapter,
       contentAdapter
     } = this._adapters;
-
+    let videoMedias = [];
+    let audioMedias = [];
     const videoDescription = this._offer.mainVideoSdp;
     const audioDescription = this._offer.audioSdp;
-    Logger.trace('[mcs-sdp-session] Defiling this beloved SDP for session', this.id, videoDescription, audioDescription);
-    const videoMedias = await videoAdapter.negotiate(this.roomId, this.userId, this.id,
-      videoDescription, this._type, this._options);
-    const audioMedias = await audioAdapter.negotiate(this.roomId, this.userId, this.id,
-      audioDescription, this._type, this._options);
+
+    if (videoDescription) {
+      Logger.trace('[mcs-sdp-session] Processing multiadapter video SDP for', this.id, videoDescription);
+      videoMedias = await videoAdapter.negotiate(this.roomId, this.userId, this.id,
+        videoDescription, this._type, this._options);
+    }
+
+    if (audioDescription) {
+      Logger.trace('[mcs-sdp-session] Processing multiadapter audio SDP for', this.id, audioDescription);
+      audioMedias = await audioAdapter.negotiate(this.roomId, this.userId, this.id,
+        audioDescription, this._type, this._options);
+    }
 
     this.medias = this.medias.concat(videoMedias, audioMedias);
 
@@ -77,7 +84,8 @@ module.exports = class SDPSession extends MediaSession {
   renegotiateStreams () {
     return new Promise(async (resolve, reject) => {
       try {
-        // For now we only support renegotiation for content streams
+        // For now we only support full renegotiation for content streams. Anything
+        // else will be re-sent as previously processed
         const {
           contentAdapter
         } = this._adapters;
@@ -93,6 +101,8 @@ module.exports = class SDPSession extends MediaSession {
           this.setAnswer(contentAnswer + "a=content:slides\r\n");
           return resolve(contentAnswer + "a=content:slides\r\n");
         }
+
+        return resolve(this.getAnswer());
       } catch (e) {
         return reject(this._handleError(e));
       }
@@ -129,6 +139,10 @@ module.exports = class SDPSession extends MediaSession {
         Logger.trace('[mcs-sdp-session] The wizard responsible for this session', this.id, 'processed the following answers', answer);
 
         // Checks if the media server was able to find a compatible media line
+        if (this.medias.length <= 0) {
+          return reject(this._handleError(C.ERROR.MEDIA_NO_AVAILABLE_CODEC));
+        }
+
         if (this._offer && answer) {
           if (!this._hasAvailableCodec()) {
             return reject(this._handleError(C.ERROR.MEDIA_NO_AVAILABLE_CODEC));

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -209,6 +209,12 @@ module.exports = class SdpWrapper {
   static getAudioDescription (sdp) {
     var res = transform.parse(sdp);
     res.media = res.media.filter(function (ml) { return ml.type == "audio" });
+
+    // Everything has been filtered and no audio was found
+    if (res.media.length <= 0) {
+      return;
+    }
+
     // Hack: Some devices (Snom, Pexip) send crypto with RTP/AVP
     // That is forbidden according to RFC3711 and FreeSWITCH rebukes it
     res = SdpWrapper.removeTransformCrypto(res);
@@ -231,6 +237,12 @@ module.exports = class SdpWrapper {
     // Filter should also carry && ml.invalid[0].value != 'content:slides';
     // when content is enabled
     res.media = res.media.filter(function (ml) { return ml.type === "video" }); // && ml.invalid[0].value != 'content:slides'});
+
+    // Everything has been filtered and no audio was found
+    if (res.media.length <= 0) {
+      return;
+    }
+
     var mangledSdp = transform.write(res);
     if (typeof mangledSdp != undefined && mangledSdp && mangledSdp != "") {
       return mangledSdp;
@@ -503,7 +515,7 @@ module.exports = class SdpWrapper {
     let res = typeof sdp === 'string'? transform.parse(sdp) : sdp;
     let validPayloads;
 
-    res.media.forEach(ml => {
+    res.media.forEach((ml, index) => {
       if (ml.type === 'video' && codec !== 'ANY') {
         // Video: filter by @codec
         ml.rtp = ml.rtp.filter((elem) => {
@@ -527,6 +539,11 @@ module.exports = class SdpWrapper {
         }
 
         ml.payloads = validPayloads.join(' ');
+
+        // Check is the media line has no available codec and strip it off
+        if (!ml.rtp || ml.rtp.length <= 0 || ml.payloads === '') {
+          res.media.splice(index, 1);
+        }
       } else {
         // passthrough filtering
         validPayloads = ml.rtp.map((elem) => {

--- a/lib/screenshare/ScreenshareManager.js
+++ b/lib/screenshare/ScreenshareManager.js
@@ -136,7 +136,7 @@ module.exports = class ScreenshareManager extends BaseManager {
   _handleRoomCreated (event) {
     const { room } = event;
     this.mcs.onEvent('roomDestroyed', room, (event) => {
-      Logger.debug(this._logPrefix, "Room", event.room, "destroyed");
+      Logger.debug(this._logPrefix, "Room", room, "destroyed");
       try {
         this._stopSession(room);
       } catch (e) {


### PR DESCRIPTION
* Hardened the FreeSWITCH adapter `connect` method error handling
* General improvements to some trace loggings throughout the code
* Some cleanup on deprecated `subscribedSessions` code
* Added extra checks in the kurento adapter for when the pipeline was already released
* Fix regression on MEDIA_NO_AVAILABLE_CODEC error triggering
  - Also improved the procedures to filter SDPs by codec and made the processing of SDPs with no specific media lines (lacking audio, video) more natural and resilient