### PR TITLE
Modify dockerfile to make it work with the new postinstall script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR app
 ENV NODE_ENV production
 
 RUN cp config/default.example.yml config/production.yml \
- && npm install \
+ && npm install --unsafe-perm \
  && npm cache clear --force
 
 EXPOSE 3008


### PR DESCRIPTION
We added a sip.js fork which needs a npm postinstall script. Added the unsafe-perm opt to the Dockerfile so it can build the image correctly.