### PR TITLE
Fixed hangup detection of FS sessions when we act as offerer

### DIFF
--- a/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
+++ b/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
@@ -82,15 +82,18 @@ module.exports = class Freeswitch extends EventEmitter {
   }
 
   _handleChannelHangup (channelId, callId) {
-    let channelInfo = this._channelIdInfos[channelId];
+    const channelInfo = this._channelIdInfos[channelId];
     if (channelInfo) {
       const elementId = channelInfo.ua;
-      //const elementId = this._channelIdInfos[channelId].ua;
       const userAgent = this._userAgents[elementId];
-      if (userAgent && !userAgent.session) {
-        // user joined externally, need to cleanup;
-        this.emit(C.EVENT.MEDIA_DISCONNECTED+elementId);
-        this._deleteChannelMappings(elementId);
+      if (userAgent) {
+        const { session } = userAgent;
+        if (!session || session.isOfferer) {
+          // user joined externally or we are the offerer (FS enable-3ppc=proxy bug)
+          // need to cleanup here instead of anchoring on sip.js;
+          this.emit(C.EVENT.MEDIA_DISCONNECTED+elementId);
+          this._deleteChannelMappings(elementId);
+        }
       }
     }
   }
@@ -430,6 +433,7 @@ module.exports = class Freeswitch extends EventEmitter {
           );
 
           session.sessionId = userAgent.userAgentId;
+          session.isOfferer = !sdpOffer;
           userAgent.session = session;
 
           const handleOffer = async (offer) => {


### PR DESCRIPTION
Not proud of it, but FreeSWITCH has a bug where it doesn't end properly the SIP session initiated without SDP when enable-3pcc=proxy is set in its config. So I did what needed to be done.