### PR TITLE
Spoof upper layer process class and use it in mcs-core (#54)

### DIFF
--- a/lib/mcs-core/lib/utils/base-process.js
+++ b/lib/mcs-core/lib/utils/base-process.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const Logger = require('./logger');
+const C = require('../constants/constants.js');
+const config = require('config');
+
+module.exports = class BaseProcess {
+  constructor(controller, logPrefix = '[mcs-core-base-process]') {
+    this.runningState = "RUNNING";
+    this.controller = controller;
+    this.logPrefix = logPrefix;
+  }
+
+  start () {
+    this.controller.start();
+
+    if (config.has('acceptSelfSignedCertificate') && config.get('acceptSelfSignedCertificate')) {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED=0;
+    }
+
+    process.on('disconnect', this.stop.bind(this));
+    process.on('SIGTERM', this.stop.bind(this));
+    process.on('SIGINT', this.stop.bind(this));
+    process.on('uncaughtException', this.handleException.bind(this));
+    process.on('unhandledRejection', this.handleRejection.bind(this));
+  }
+
+  async stop () {
+    try {
+      this.runningState = "STOPPING";
+      Promise.race([this.controller.stop(), this._failOver()]).then(() => {
+        Logger.info(this.logPrefix, "Exiting process with code 0");
+        process.exit();
+      });
+    }
+    catch (err) {
+      Logger.error(this.logPrefix, "Error on exit. Exiting process with code 1", err);
+      process.exit(1);
+    }
+  }
+
+  _failOver () {
+    return new Promise((resolve, reject) => {
+      setTimeout(resolve, 5000);
+    });
+  }
+
+  handleException (error) {
+    Logger.error(this.logPrefix, 'TODO => Uncaught exception', error.stack);
+    if (this.runningState === "STOPPING") {
+      Logger.warn(this.logPrefix, "Exiting process with code 1");
+      process.exit(1);
+    }
+  }
+
+  handleRejection (reason, promise) {
+    Logger.error(this.logPrefix, 'TODO => Unhandled Rejection at: Promise', promise, 'reason:', reason);
+    if (this.runningState === "STOPPING") {
+      Logger.warn(this.logPrefix, "Exiting process with code 1");
+      process.exit(1);
+    }
+  }
+}

--- a/lib/mcs-core/process.js
+++ b/lib/mcs-core/process.js
@@ -1,60 +1,52 @@
-/*
- * WIP: the mcs-core lib will be turned into a dependecy sometime in the near
- * future, and it will probably act with a separate process that answers via
- * its own redis channel
- */
-
 'use strict';
-const Logger = require('./lib/utils/logger');
-const MMR = require('./lib/media/mcs-message-router');
+const Logger = require('./lib/utils/logger.js');
+const MMR = require('./lib/media/mcs-message-router.js');
+const BaseProcess = require('./lib/utils/base-process.js');
 const API = require('mcs-js');
 const http = require('http');
 const config = require('config');
 
-const controller = MMR;
-controller.start();
+const controllerInstance = MMR;
 
-Logger.info('[app] MCS Server is initializing ...');
+class CoreProcess extends BaseProcess {
+  constructor (controller, prefix) {
+    super(controller, prefix)
+  }
 
-// HTTPS server
-const port = config.get('mcs-port');
-const connectionTimeout = config.get('mcs-ws-timeout');
-const serverHttps = http.createServer().listen(port, () => {
-  Logger.info('[app] MCS Server is ready to receive connections');
-});
+  startMCSServer () {
+    // HTTPS server
+    const port = config.get('mcs-port');
+    const connectionTimeout = config.get('mcs-ws-timeout');
+    const serverHttps = http.createServer().listen(port, () => {
+      Logger.info('[app] MCS Server is ready to receive connections');
+    });
 
-const mcsServer = new API.Server({
-  path: config.get('mcs-path'),
-  server: serverHttps,
-  connectionTimeout
-});
+    const mcsServer = new API.Server({
+      path: config.get('mcs-path'),
+      server: serverHttps,
+      connectionTimeout
+    });
 
-mcsServer.on('connection', controller.setupClient.bind(controller));
+    mcsServer.on('connection', this.controller.setupClient.bind(this.controller));
+  }
 
-const exit = async () => {
-  try {
-    const ret = await controller.stop();
-    process.exit(ret);
-  } catch (e) {
-    process.exit(1);
+  handleException (error) {
+    if (error.code === 'EADDRINUSE') {
+      Logger.warn(this.logPrefix, "There's probably another master mcs-core instance running, kill this one");
+      this.stop();
+      return;
+    }
+
+    Logger.error(this.logPrefix, 'TODO => Uncaught exception', error.stack);
+
+    if (this.runningState === "STOPPING") {
+      Logger.warn(this.logPrefix, "Exiting process with code 1");
+      process.exit(1);
+    }
   }
 }
 
-process.on('SIGINT', exit.bind(controller));
+const coreProcess = new CoreProcess(controllerInstance, '[mcs-core]');
 
-process.on('SIGTERM', exit.bind(controller));
-
-process.on('uncaughtException', (e) => {
-  if (e.code === 'EADDRINUSE') {
-    Logger.warn("[mcs-core] There's probably another master SFU instance running, keep this one as slave");
-    exit();
-    return;
-  }
-
-  Logger.error('[mcs-core] Uncaught exception', e.stack);
-});
-
-process.on('unhandledRejection', (e1, e2) => {
-  Logger.error('[mcs-core] Unhandled exception', e1, e2);
-});
-
+coreProcess.start();
+coreProcess.startMCSServer();


### PR DESCRIPTION
Addresses #54. mcs-core's process shouldn't hang anymore).
The base-process duplication is needed to avoid coupling things even more.