### PR TITLE
Version v2.4.2

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -44,3 +44,6 @@ processes:
 conference-media-specs:
   codec_video_main: CODEC_VIDEO_MAIN
   codec_video_content: CODEC_VIDEO_CONTENT
+
+videoSubscriberSpecSlave: VIDEO_SUBSCRIBER_SLAVE
+screenshareSubscriberSpecSlave: SCREENSHARE_SUBSCRIBER_SLAVE

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -36,6 +36,8 @@ to-html5: to-html5-redis-channel
 common-message-version: 2.x
 screenshareKeyframeInterval: 0
 screenshareEnableFlashRTPBridge: false
+screenshareSubscriberSpecSlave: false
+videoSubscriberSpecSlave: false
 
 recordScreenSharing: true
 recordWebcams: true

--- a/lib/base/BaseProvider.js
+++ b/lib/base/BaseProvider.js
@@ -103,8 +103,7 @@ module.exports = class BaseProvider extends EventEmitter {
   }
 
 
-  getRecordingPath (room, subPath, recordingName) {
-    const format = config.get('recordingFormat');
+  getRecordingPath (room, subPath, recordingName, format) {
     const basePath = config.get('recordingBasePath');
     const timestamp = (new Date()).getTime();
 

--- a/lib/base/MCSAPIWrapper.js
+++ b/lib/base/MCSAPIWrapper.js
@@ -153,9 +153,9 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
     }
   }
 
-  async startRecording(userId, mediaId, recordingPath) {
+  async startRecording(userId, mediaId, recordingPath, options) {
     try {
-      const { recordingId } = await this._mcs.startRecording(userId, mediaId, recordingPath);
+      const { recordingId } = await this._mcs.startRecording(userId, mediaId, recordingPath, options);
       return recordingId;
     }
     catch (error) {

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -14,6 +14,10 @@ const config = require('config');
         AUDIO: "AUDIO",
         VIDEO: "VIDEO",
         ALL: "ALL",
+        RECORDING_PROFILE_WEBM: 'WEBM_VIDEO_ONLY',
+        RECORDING_PROFILE_MKV: 'MKV_VIDEO_ONLY',
+        RECORDING_FORMAT_WEBM: 'webm',
+        RECORDING_FORMAT_MKV: 'mkv',
 
         // SFU app types
         SCREENSHARE_APP:  'screenshare',

--- a/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
+++ b/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
@@ -394,6 +394,7 @@ module.exports = class Freeswitch extends EventEmitter {
     return session.mediaHandler.setRemoteOffer(descriptor);
   }
 
+  // TODO this method is screaming for a refactor.
   async processOffer (elementId, sdpOffer, params) {
     const userAgent = this._userAgents[elementId];
     const { voiceBridge } = userAgent;
@@ -450,7 +451,13 @@ module.exports = class Freeswitch extends EventEmitter {
             session.mediaHandler.setRemoteOffer(procAns);
           }
 
+          const handleReinvite = (reinviteSDP) => {
+            Logger.info(LOG_PREFIX, `re-INVITE received for element ${elementId}`);
+            session.mediaHandler.setReinviteAnswer(session.localSDP);
+          };
+
           session.once(C.EVENT.REMOTE_SDP_RECEIVED, handleOffer.bind(this));
+          session.on(C.EVENT.REINVITE, handleReinvite.bind(this));
 
           const handleNegotiationError = (c) => {
             this._deleteChannelMappings(elementId);
@@ -466,6 +473,7 @@ module.exports = class Freeswitch extends EventEmitter {
             }
 
             const answer = hackProxyViaKurento ? proxyAnswer : session.mediaHandler._sdpResponse;
+            session.localSDP = answer;
             isNegotiated = true;
 
             return resolve(answer);
@@ -509,7 +517,6 @@ module.exports = class Freeswitch extends EventEmitter {
             this.emit(C.EVENT.MEDIA_DISCONNECTED+elementId);
             handleNegotiationError();
           });
-
         } else {
           return reject(C.ERROR.MEDIA_NOT_FOUND);
         }

--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -468,6 +468,12 @@ module.exports = class Kurento extends EventEmitter {
           return reject(this._handleError(ERRORS[40101].error));
         }
 
+        Logger.info(LOG_PREFIX, "Adapter elements to be connected", JSON.stringify({
+          sourceId: source.id,
+          sinkId: sink.id,
+          connectionType: type,
+        }));
+
         switch (type) {
           case C.CONNECTION_TYPE.ALL:
             source.connect(sink, (error) => {

--- a/lib/mcs-core/lib/constants/constants.js
+++ b/lib/mcs-core/lib/constants/constants.js
@@ -6,6 +6,8 @@
 
 'use strict'
 
+const config = require('config');
+
 exports.ALL = 'ALL'
 
 exports.STATUS = {}
@@ -41,6 +43,8 @@ exports.CONNECTION_TYPE.ALL = 'ALL'
 exports.NEGOTIATION_ROLE = {}
 exports.NEGOTIATION_ROLE.OFFERER = 'offerer';
 exports.NEGOTIATION_ROLE.ANSWERER = 'answerer';
+
+exports.DEFAULT_MEDIA_SPECS = JSON.parse(JSON.stringify(config.get('conference-media-specs')));
 
 // Media server state changes
 exports.EMAP = {

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -115,8 +115,8 @@ const MR = class MCSRouter {
   async startRecording(args) {
     const { userId, mediaId, recordingPath } = args;
     try {
-      const { userId, mediaId, recordingPath } = args;
-      const answer = await this._mediaController.startRecording(userId, mediaId, recordingPath);
+      const { userId, mediaId, recordingPath, params } = args;
+      const answer = await this._mediaController.startRecording(userId, mediaId, recordingPath, params);
       return (answer);
     }
     catch (error) {

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -81,14 +81,14 @@ module.exports = class MediaController {
   }
 
   async join (roomId, type, params) {
-    Logger.info(LOG_PREFIX, "Join room => " + roomId + ' as ' + type);
     try {
       const room = await this.createRoom(roomId);
       // Inherit strategy from room unless it was directly specified
       params.strategy = params.strategy || room.strategy;
       const user = this.createUser(roomId, type, params);
       room.addUser(user);
-      Logger.info(LOG_PREFIX, "Resolving user " + user.id);
+
+      Logger.info(LOG_PREFIX, `User ${user.id} joined room ${roomId} as ${type}`);
       return Promise.resolve(user.id);
     } catch (e) {
       return Promise.reject(this._handleError(e));
@@ -97,7 +97,7 @@ module.exports = class MediaController {
   }
 
   async leave (roomId, userId) {
-    Logger.info(LOG_PREFIX, "User", userId, "wants to leave.");
+    Logger.info(LOG_PREFIX, `User ${userId} wants to leave room ${roomId}`);
     let user, room;
 
     try {
@@ -136,7 +136,7 @@ module.exports = class MediaController {
 
   publishAndSubscribe (roomId, userId, sourceId, type, params = {}) {
     return new Promise(async (resolve, reject) => {
-      Logger.info(LOG_PREFIX, "PublishAndSubscribe from user", userId, "to source", sourceId);
+      Logger.info(LOG_PREFIX, `PublishAndSubscribe from user ${userId} to source ${sourceId}`);
       Logger.trace("[mcs-controler] PublishAndSubscribe descriptor is", params.descriptor);
 
       try {
@@ -205,45 +205,48 @@ module.exports = class MediaController {
 
   subscribe (userId, sourceId, type, params = {}) {
     return new Promise(async (resolve, reject) => {
-      Logger.info(LOG_PREFIX, "Subscribe from user", userId, "to source", sourceId);
+      Logger.info(LOG_PREFIX, `Subscribe from user ${userId} to source ${sourceId}`);
       Logger.trace("[mcs-controler] Subscribe descriptor is", params.descriptor);
+      let source, user, room;
 
       try {
-        let source;
-        const user = await this.getUser(userId);
-        const room = await this.getRoom(user.roomId);
+        user = await this.getUser(userId);
+        room = await this.getRoom(user.roomId);
         if (sourceId === C.MEDIA_PROFILE.CONTENT) {
           source = this.getMediaSession(room._contentFloor.id);
           params.content = true;
         } else {
           source = this.getMediaSession(sourceId);
         }
+      } catch (e) {
+        return reject(this._handleError(e));
+      }
 
-        type = C.EMAP[type];
+      type = C.EMAP[type];
 
-        switch (type) {
-          case C.MEDIA_TYPE.RTP:
-          case C.MEDIA_TYPE.WEBRTC:
-          case C.MEDIA_TYPE.URI:
+      switch (type) {
+        case C.MEDIA_TYPE.RTP:
+        case C.MEDIA_TYPE.WEBRTC:
+        case C.MEDIA_TYPE.URI:
+          try {
             const  { session, answer } = await user.subscribe(params.descriptor, type, source, params);
             this.addMediaSession(session);
             room.addMediaSession(session);
             resolve({descriptor: answer, mediaId: session.id});
             session.sessionStarted();
-            break;
-          default:
-            return reject(this._handleError(C.ERROR.MEDIA_INVALID_TYPE));
-        }
-      }
-      catch (err) {
-        reject(this._handleError(err));
+          } catch (e) {
+            return reject(this._handleError(e));
+          }
+          break;
+        default:
+          return reject(this._handleError(C.ERROR.MEDIA_INVALID_TYPE));
       }
     });
   }
 
   async unpublish (userId, mediaId) {
     try {
-      Logger.info(LOG_PREFIX, "Unpublishing media", mediaId, "of user", userId);
+      Logger.info(LOG_PREFIX, `Unpublishing media ${mediaId} of user ${userId}`);
       const user = this.getUser(userId);
       const room = await this.getRoom(user.roomId);
       const answer = await user.unpublish(mediaId);
@@ -260,7 +263,7 @@ module.exports = class MediaController {
 
   async unsubscribe (userId, mediaId) {
     try {
-      Logger.info(LOG_PREFIX, "Unsubscribing media", mediaId, "of user", userId);
+      Logger.info(LOG_PREFIX, `Unsubscribing media ${mediaId} of user ${userId}`);
       const user = this.getUser(userId);
       const room = await this.getRoom(user.roomId);
       const media = this.getMediaSession(mediaId);
@@ -283,7 +286,12 @@ module.exports = class MediaController {
         const room = await this.getRoom(user.roomId);
         const sourceSession = this.getMediaSession(sourceId);
 
-        const { recordingSession, answer } = await user.startRecording(recordingPath, C.MEDIA_TYPE.RECORDING, sourceSession, params);
+        const { recordingSession, answer } = await user.startRecording(
+          recordingPath,
+          C.MEDIA_TYPE.RECORDING,
+          sourceSession,
+          params
+        );
 
         this.addMediaSession(recordingSession);
         room.addMediaSession(recordingSession);
@@ -318,7 +326,7 @@ module.exports = class MediaController {
 
   connect (sourceId, sinkId, type = 'ALL') {
     return new Promise(async (resolve, reject) => {
-      Logger.info(LOG_PREFIX, "Connect", sourceId, "to", sinkId, "with type", type);
+      Logger.info(LOG_PREFIX, `Connect ${sourceId} to ${sinkId} with type ${type}`);
 
       try {
         const sourceSession = this.getMediaSession(sourceId);
@@ -336,7 +344,7 @@ module.exports = class MediaController {
   disconnect (sourceId, sinkId, type = 'ALL') {
     return new Promise(async (resolve, reject) => {
       try {
-        Logger.info(LOG_PREFIX, "Disconnect", sourceId, "from", sinkId, "with type", type);
+        Logger.info(LOG_PREFIX, `Disconnect ${sourceId} from ${sinkId} with type ${type}`);
         const sourceSession = this.getMediaSession(sourceId);
         const sinkSession = this.getMediaSession(sinkId);
 
@@ -354,7 +362,6 @@ module.exports = class MediaController {
       try {
         const session = this.getMediaSession(mediaId);
         await session.addIceCandidate(candidate);
-
         return resolve();
       }
       catch (err) {
@@ -657,7 +664,6 @@ module.exports = class MediaController {
     return new Promise(async (resolve, reject) => {
       try {
         const room = await this.getRoom(roomId);
-        Logger.info(LOG_PREFIX, 'Fetched room', room.id);
         resolve(room.getConferenceFloor());
       } catch (error) {
         reject(this._handleError(error));
@@ -669,7 +675,6 @@ module.exports = class MediaController {
     return new Promise(async (resolve, reject) => {
       try {
         const mediaSession = this.getMediaSession(mediaId);
-        Logger.info(LOG_PREFIX,'Fetched media', mediaSession.id);
         await mediaSession.setVolume(volume);
         resolve();
       } catch (error) {
@@ -682,7 +687,6 @@ module.exports = class MediaController {
     return new Promise(async (resolve, reject) => {
       try {
         const mediaSession = this.getMediaSession(mediaId);
-        Logger.info(LOG_PREFIX,'Fetched media', mediaSession.id);
         await mediaSession.mute();
         resolve();
       } catch (error) {
@@ -695,7 +699,6 @@ module.exports = class MediaController {
     return new Promise(async (resolve, reject) => {
       try {
         const mediaSession = this.getMediaSession(mediaId);
-        Logger.info(LOG_PREFIX,'Fetched media', mediaSession.id);
         await mediaSession.unmute();
         resolve();
       } catch (error) {

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -206,7 +206,7 @@ module.exports = class MediaController {
   subscribe (userId, sourceId, type, params = {}) {
     return new Promise(async (resolve, reject) => {
       Logger.info(LOG_PREFIX, `Subscribe from user ${userId} to source ${sourceId}`);
-      Logger.trace("[mcs-controler] Subscribe descriptor is", params.descriptor);
+      Logger.trace(LOG_PREFIX, "Subscribe descriptor is", params.descriptor);
       let source, user, room;
 
       try {

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -14,7 +14,7 @@ const Logger = require('../utils/logger');
 const AdapterFactory = require('../adapters/adapter-factory');
 const { handleError } = require('../utils/util');
 const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
-const MEDIA_SPECS = config.get('conference-media-specs');
+const MEDIA_SPECS = C.DEFAULT_MEDIA_SPECS;
 const StrategyManager = require('../media/strategy-manager.js');
 
 const LOG_PREFIX = "[mcs-media-session]";
@@ -71,7 +71,7 @@ module.exports = class MediaSession {
     // Nature of the media according to the use case (video || content || audio)
     this._mediaProfile = options.mediaProfile;
     // Media specs for the media. If not specified, falls back to the default
-    this.mediaSpecs = options.mediaSpecs? options.mediaSpecs : MEDIA_SPECS;
+    this.mediaSpecs = options.mediaSpecs? options.mediaSpecs : {...MEDIA_SPECS};
     this.muted = false;
     this.volume = 50;
     // Switching strategy

--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -12,7 +12,7 @@ const config = require('config');
 const Logger = require('../utils/logger');
 const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
 const { handleError } = require('../utils/util');
-const MEDIA_SPECS = config.get('conference-media-specs');
+const MEDIA_SPECS = C.DEFAULT_MEDIA_SPECS;
 const StrategyManager = require('../media/strategy-manager.js');
 const MediaFactory = require('../media/media-factory');
 
@@ -63,7 +63,7 @@ module.exports = class Media {
     this._iceSubscription = false;
 
     // Media specs for the media. If not specified, falls back to the default
-    this.mediaSpecs = options.mediaSpecs? options.mediaSpecs : MEDIA_SPECS;
+    this.mediaSpecs = options.mediaSpecs? options.mediaSpecs : {...MEDIA_SPECS};
 
     // Media ID that serves as a subscription source tracker for a sink media
     this._subscribedTo = "";

--- a/lib/mcs-core/lib/model/recording-session.js
+++ b/lib/mcs-core/lib/model/recording-session.js
@@ -11,17 +11,15 @@ const Logger = require('../utils/logger');
 const C = require('../constants/constants');
 const LOG_PREFIX = "[mcs-recording-session]";
 
-
 module.exports = class RecordingSession extends MediaSession {
   constructor(room, user, recordingPath, options) {
     const uri = recordingPath;
     const recordingOptions = {
-      ... options,
       recordingProfile: config.get('recordingMediaProfile'),
       uri: uri,
-      stopOnEndOfStream: true
+      stopOnEndOfStream: true,
+      ...options,
     };
-
     super(room, user, C.MEDIA_TYPE.RECORDING, recordingOptions);
     this.filename = uri;
     this.sourceMedia = this._options.sourceMedia;

--- a/lib/mcs-core/lib/model/sdp-media.js
+++ b/lib/mcs-core/lib/model/sdp-media.js
@@ -31,6 +31,7 @@ module.exports = class SDPMedia extends Media {
     // {SdpWrapper} SdpWrapper
     this._remoteDescriptor;
     this._localDescriptor;
+    this.negotiationRole = '';
 
     if (localDescriptor) {
       this.localDescriptor = localDescriptor;
@@ -49,8 +50,16 @@ module.exports = class SDPMedia extends Media {
         this._shouldRenegotiate = true;
       }
 
+      if (this.localDescriptor == null && !this.negotiationRole) {
+        this.negotiationRole = C.NEGOTIATION_ROLE.ANSWERER;
+      }
+
       this._remoteDescriptor = new SdpWrapper(remoteDescriptor, this.mediaSpecs, this.mediaProfile);
       this.fillMediaTypes(this.remoteDescriptor);
+
+      if (this.negotiationRole === C.NEGOTIATION_ROLE.OFFERER) {
+        this.mediaSpecs = SdpWrapper.updateSpecWithChosenCodecs(this.remoteDescriptor);
+      }
     }
   }
 
@@ -70,8 +79,17 @@ module.exports = class SDPMedia extends Media {
       // The remote mediaTypes will be re-set once the remote offer comes through
       if (this.remoteDescriptor == null) {
         this.fillMediaTypes(this.localDescriptor);
+        if (!this.negotiationRole) {
+          this.negotiationRole = C.NEGOTIATION_ROLE.OFFERER;
+        }
       }
+
+
       this._updateHostLoad();
+
+      if (this.negotiationRole === C.NEGOTIATION_ROLE.ANSWERER) {
+        this.mediaSpecs = SdpWrapper.updateSpecWithChosenCodecs(this.localDescriptor);
+      }
     }
   }
 

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -54,6 +54,10 @@ module.exports = class SDPSession extends MediaSession {
       }
 
       this._remoteDescriptor = new SdpWrapper(remoteDescriptor, this.mediaSpecs, this._mediaProfile);
+
+      if (this.negotiationRole === C.NEGOTIATION_ROLE.OFFERER) {
+        this.mediaSpecs = SdpWrapper.updateSpecWithChosenCodecs(this.remoteDescriptor);
+      }
     }
   }
 
@@ -80,6 +84,10 @@ module.exports = class SDPSession extends MediaSession {
 
       if (this.remoteDescriptor == null && !this.negotiationRole) {
         this.negotiationRole = C.NEGOTIATION_ROLE.OFFERER;
+      }
+
+      if (this.negotiationRole === C.NEGOTIATION_ROLE.ANSWERER) {
+        this.mediaSpecs = SdpWrapper.updateSpecWithChosenCodecs(this.localDescriptor);
       }
     }
   }

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -94,9 +94,10 @@ module.exports = class User {
   subscribe (sdp, type, source, params = {}) {
     return new Promise(async (resolve, reject) => {
       try {
-        // If there's not source media specs, fetch the source's media specs to
+        // If there's no source media specs, fetch the source's media specs to
         // make the subscriber match it
-        if (params.mediaSpecs == null) {
+        if (source.mediaSpecs && (params.mediaSpecs == null || params.mediaSpecSlave)) {
+          Logger.info(LOG_PREFIX, `Subscribe from user ${this.id} to source ${source.id} has media spec slaved`);
           params.mediaSpecs = source.mediaSpecs;
         }
 

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -617,6 +617,61 @@ module.exports = class SdpWrapper {
     return res;
   };
 
+  // updatedWrapper is a SDPWrapper instance which can be operated upon
+  // TODO update the subparameters of the spec as well (.H264, .VP8, .OPUS)
+  static updateSpecWithChosenCodecs (updatedWrapper) {
+    const res = updatedWrapper._jsonSdp;
+    const codecMap = {
+      codec_video_main: null,
+      codec_video_content: null,
+      codec_audio: null,
+    }
+
+    res.media.forEach(ml => {
+      if (ml.type == 'video') {
+        const hasContentSlides = ml.invalid
+          ? ml.invalid.some(({ value }) => { return value.includes('slides') })
+          : false;
+        if (updatedWrapper.mediaProfile === C.MEDIA_PROFILE.MAIN || !hasContentSlides) {
+          if (!codecMap.codec_video_main) {
+            ml.rtp.some(rtp => {
+              if (!codecMap.codec_video_main) {
+                codecMap.codec_video_main = rtp.codec.toUpperCase();
+                return true;
+              }
+            });
+          }
+        } else if (updatedWrapper.mediaProfile === C.MEDIA_PROFILE.CONTENT || hasContentSlides) {
+          if (!codecMap.codec_video_content) {
+            ml.rtp.some(rtp => {
+              if (!codecMap.codec_video_content) {
+                codecMap.codec_video_content = rtp.codec.toUpperCase();
+                return true;
+              }
+            });
+          }
+        }
+      }
+
+      if (!codecMap.codec_audio) {
+        if (ml.type === 'audio') {
+          ml.rtp.some(rtp => {
+            if (!codecMap.codec_audio) {
+              codecMap.codec_audio= rtp.codec.toUpperCase();
+              return true;
+            }
+          });
+        }
+      }
+    });
+
+    const { codec_video_main, codec_video_content, codec_audio } = codecMap;
+    updatedWrapper.mediaSpecs.codec_video_main = codec_video_main? codec_video_main : updatedWrapper.mediaSpecs.codec_video_main;
+    updatedWrapper.mediaSpecs.codec_video_content = codec_video_content? codec_video_content: updatedWrapper.mediaSpecs.codec_video_content;
+    updatedWrapper.mediaSpecs.codec_audio = codec_audio? codec_audio : updatedWrapper.mediaSpecs.codec_audio;
+    return updatedWrapper.mediaSpecs;
+  }
+
   static convertToString (jsonSdp) {
     return transform.write(jsonSdp);
   }

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -457,9 +457,12 @@ module.exports = class SdpWrapper {
             let fmtps = ml.fmtp.filter(f => f.payload === rtp.payload);
             fmtps.forEach(fmtp => {
               let fmtpConfig = transform.parseParams(fmtp.config);
-              // Reconfiguring the FMTP to coerce endpoints to obey to audio
-              let configProfile = this._fetchOPUSProfileParams(spec[audioCodec]);
-              fmtp.config = configProfile;
+              // Reconfiguring the FMTP to coerce endpoints to obey to audio spec
+              // IF audioCodec was defined in the spec
+              if (spec[audioCodec]) {
+                let configProfile = this._fetchOPUSProfileParams(spec[audioCodec]);
+                fmtp.config = configProfile;
+              }
             });
           }
         });

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -21,6 +21,9 @@ const ENABLE_SCREENSHARE_FLASH_BRIDGE = config.has('screenshareEnableFlashRTPBri
   ? config.get('screenshareEnableFlashRTPBridge')
   : false;
 const DEFAULT_MEDIA_SPECS = config.get('conference-media-specs');
+const SUBSCRIBER_SPEC_SLAVE = config.has('videoSubscriberSpecSlave')
+  ? config.get('videoSubscriberSpecSlave')
+  : false;
 
 const LOG_PREFIX = "[screenshare]";
 
@@ -419,6 +422,7 @@ module.exports = class Screenshare extends BaseProvider {
           descriptor: sdpOffer,
           name: this._assembleStreamName('subscribe', userId, this._voiceBridge),
           mediaProfile: 'content',
+          mediaSpecSlave: SUBSCRIBER_SPEC_SLAVE,
         }
 
         if (this._presenterEndpoint == null) {

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -20,6 +20,7 @@ const KEYFRAME_INTERVAL = config.get('screenshareKeyframeInterval');
 const ENABLE_SCREENSHARE_FLASH_BRIDGE = config.has('screenshareEnableFlashRTPBridge')
   ? config.get('screenshareEnableFlashRTPBridge')
   : false;
+const DEFAULT_MEDIA_SPECS = config.get('conference-media-specs');
 
 const LOG_PREFIX = "[screenshare]";
 
@@ -208,8 +209,25 @@ module.exports = class Screenshare extends BaseProvider {
   async startRecording() {
     return new Promise(async (resolve, reject) => {
       try {
-        const recordingPath = this.getRecordingPath(this._meetingId, this._recordingSubPath, this._voiceBridge);
-        const recordingId = await this.mcs.startRecording(this.presenterMCSUserId, this._presenterEndpoint, recordingPath);
+        const contentCodec = DEFAULT_MEDIA_SPECS.codec_video_content;
+        const recordingProfile = (contentCodec === 'VP8' || contentCodec === 'ANY')
+          ? C.RECORDING_PROFILE_WEBM
+          : C.RECORDING_PROFILE_MKV;
+        const format = (contentCodec === 'VP8' || contentCodec === 'ANY')
+          ? C.RECORDING_FORMAT_WEBM
+          : C.RECORDING_FORMAT_MKV;
+        const recordingPath = this.getRecordingPath(
+          this._meetingId,
+          this._recordingSubPath,
+          this._voiceBridge,
+          format
+        );
+        const recordingId = await this.mcs.startRecording(
+          this.presenterMCSUserId,
+          this._presenterEndpoint,
+          recordingPath,
+          { recordingProfile }
+        );
         this.recording = { recordingId, filename: recordingPath };
         this.mcs.onEvent(C.MEDIA_STATE, this.recording.recordingId, (event) => {
           this._recordingState(event, this.recording.recordingId);

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -9,6 +9,7 @@ const SHOULD_RECORD = config.get('recordWebcams');
 const LOG_PREFIX = "[video]";
 const emitter = require('../utils/emitter');
 const errors = require('../base/errors');
+const DEFAULT_MEDIA_SPECS = config.get('conference-media-specs');
 
 let sources = {};
 
@@ -199,9 +200,26 @@ module.exports = class Video extends BaseProvider {
   async startRecording () {
     return new Promise(async (resolve, reject) => {
       try {
+        const cameraCodec = DEFAULT_MEDIA_SPECS.codec_video_main;
         const recordingName = this._cameraProfile + '-' + this.id;
-        const recordingPath = this.getRecordingPath(this.meetingId, this._recordingSubPath, recordingName);
-        const recordingId = await this.mcs.startRecording(this.userId, this.mediaId, recordingPath);
+        const recordingProfile = (cameraCodec === 'VP8' || cameraCodec === 'ANY')
+          ? C.RECORDING_PROFILE_WEBM
+          : C.RECORDING_PROFILE_MKV;
+        const format = (cameraCodec === 'VP8' || cameraCodec === 'ANY')
+          ? C.RECORDING_FORMAT_WEBM
+          : C.RECORDING_FORMAT_MKV;
+        const recordingPath = this.getRecordingPath(
+          this.meetingId,
+          this._recordingSubPath,
+          recordingName,
+          format
+        );
+        const recordingId = await this.mcs.startRecording(
+          this.userId,
+          this.mediaId,
+          recordingPath,
+          { recordingProfile }
+        );
         this.recording = { recordingId, filename: recordingPath, recordingPath };
         this.mcs.onEvent(C.MEDIA_STATE, this.recording.recordingId, (event) => {
           this._recordingState(event, this.recording.recordingId);
@@ -323,6 +341,7 @@ module.exports = class Video extends BaseProvider {
         descriptor,
         name: this._assembleStreamName('subscribe', this.id, this.voiceBridge),
         mediaSpecs,
+        mediaSpecSlave: true,
       }
       Logger.info(LOG_PREFIX, 'Subscribing to', sources[this.id], 'from', this.id);
       const { mediaId, answer } = await this.mcs.subscribe(this.userId, sources[this.id], C.WEBRTC, options);

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -10,6 +10,9 @@ const LOG_PREFIX = "[video]";
 const emitter = require('../utils/emitter');
 const errors = require('../base/errors');
 const DEFAULT_MEDIA_SPECS = config.get('conference-media-specs');
+const SUBSCRIBER_SPEC_SLAVE = config.has('videoSubscriberSpecSlave')
+  ? config.get('videoSubscriberSpecSlave')
+  : false;
 
 let sources = {};
 
@@ -341,7 +344,7 @@ module.exports = class Video extends BaseProvider {
         descriptor,
         name: this._assembleStreamName('subscribe', this.id, this.voiceBridge),
         mediaSpecs,
-        mediaSpecSlave: true,
+        mediaSpecSlave: SUBSCRIBER_SPEC_SLAVE,
       }
       Logger.info(LOG_PREFIX, 'Subscribing to', sources[this.id], 'from', this.id);
       const { mediaId, answer } = await this.mcs.subscribe(this.userId, sources[this.id], C.WEBRTC, options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
Patch release v2.4.2.

__CHANGELOG__

* Improved logging (`c95fa36`)
* Use the optional parameters from the `startRecording` API call (`c95fa36`)
* Add a subscriber media spec slave mode (`5ec3f46`, `d7e32f8`)
  - If this is enabled, medias created by the `subscribe` call will inherit the `mediaSpec` from the source media
  - Two new configuration options: `videoSubscriberSpecSlave` (env `VIDEO_SUBSCRIBER_SLAVE`),  `screenshareSubscriberSpecSlave` (env `SCREENSHARE_SUBSCRIBER_SLAVE`)
  - Disabled by default
* Correctly handle internal SIP re-INVITEs in the FreeSWITCH adapter (`f7cbefe`)