### PR TITLE
Performance experiments with client-event map and leak fixes

### DIFF
--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -231,10 +231,11 @@ module.exports = class Kurento extends EventEmitter {
               // Hence the bizarre filters
               const filterOptions = [
                 { reg: /AVPF/ig, val: 'AVP' },
-                { reg:  /a=mid:video0/, val: '' },
-                { reg: /a=rtcp-fb:[\d]+[\w\d\s]+/ig, val: '' },
-                { reg: /a=extmap:3 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/abs-send-time/ig, val: '' },
-                { reg: /a=setup:actpass/ig, val: '' }
+                { reg: /a=mid:video0\r*\n*/ig, val: '' },
+                { reg: /a=mid:audio0\r*\n*/ig, val: '' },
+                { reg: /a=rtcp-fb:.*\r*\n*/ig, val: '' },
+                { reg: /a=extmap:3 http:\/\/www.webrtc.org\/experiments\/rtp-hdrext\/abs-send-time\r*\n*/ig, val: '' },
+                { reg: /a=setup:actpass\r*\n*/ig, val: '' }
               ]
 
               answer = await this.generateOffer(mediaElement, filterOptions);

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -766,7 +766,6 @@ const MR = class MCSRouter {
 
   _removeEventFromClientEventMap (identifier, eventName) {
     const index = `${eventName}:${identifier}`
-    console.log("REMOVING", index);
     delete this.clientEventMap[index];
   }
 

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -19,7 +19,10 @@ const MR = class MCSRouter {
       this._mcs = null;
       this._mediaController = new MediaController();
       this.clients = {};
-      this.clientEventMap = [];
+      // This is a hash map of client arrays for which the keys are the available
+      // events implemented by the API augmented by the event identifier (if it's necessary).
+      // The keys are in the following format: <event-name:(identifier? identifier : 'all')>
+      this.clientEventMap = {};
       instance = this;
     }
 
@@ -564,9 +567,7 @@ const MR = class MCSRouter {
     client.on('onEvent', async (args) => {
       try {
         Logger.trace("[mcs-router] Client", client.trackingId, "subscribing to event", args);
-        const { eventName, identifier } = args;
-        const eventMap = { identifier, eventName, client };
-        this._addToClientEventMap(eventMap);
+        this._addToClientEventMap(args, client);
         await this.onEvent(args);
       } catch (e) {
         Logger.error('[mcs-router] OnEvent error', e);
@@ -752,17 +753,33 @@ const MR = class MCSRouter {
     });
   }
 
-  _addToClientEventMap (map) {
-    this.clientEventMap.push({ ...map });
+  _addToClientEventMap (eventSubscription, client) {
+    const { identifier, eventName } = eventSubscription;
+    const index = `${eventName}:${identifier}`
+    let map = this.clientEventMap[index];
+    if (!map) {
+      map = [];
+      this.clientEventMap[index] = map;
+    }
+    map.push(client);
   }
 
-  _removeFromClientEventMap (identifier, eventName) {
-    this.clientEventMap = this.clientEventMap.filter(c => !(c.identifier === identifier && c.eventName === eventName));
+  _removeEventFromClientEventMap (identifier, eventName) {
+    const index = `${eventName}:${identifier}`
+    console.log("REMOVING", index);
+    delete this.clientEventMap[index];
   }
 
   _removeClientFromEventMap (client) {
     Logger.trace('[mcs-router]', "Removing client", client.trackingId, "from event map");
-    this.clientEventMap = this.clientEventMap.filter(c => c.client.trackingId !== client.trackingId);
+    Object.keys(this.clientEventMap).forEach(idx => {
+      const map = this.clientEventMap[idx].filter(c => c.trackingId !== client.trackingId);
+      if (map.length <= 0)  {
+        delete this.clientEventMap[idx];
+      } else {
+        this.clientEventMap[idx] = map;
+      }
+    });
   }
 
   _removeClientFromTracking (client) {
@@ -774,14 +791,12 @@ const MR = class MCSRouter {
   }
 
   _getClientToDispatch (identifier, eventName) {
-    const clientMap = this.clientEventMap.filter(c => c.identifier === identifier && c.eventName === eventName);
-
-    if (clientMap.length > 0 ) {
-      Logger.trace('[mcs-router] Found', clientMap.length, 'clients', clientMap.map(c => [c.identifier, c.eventName, c.client.trackingId]))
+    const index = `${eventName}:${identifier}`
+    const clientMap = this.clientEventMap[index];
+    if (clientMap && clientMap.length > 0 ) {
+      Logger.trace('[mcs-router] Found', clientMap.length, 'clients', clientMap.map(c => c.trackingId));
     }
-
-    const clients = clientMap.map(cm => cm.client);
-    return clients || [];
+    return clientMap || [];
   }
 
   _dispatchEvents() {
@@ -800,31 +815,29 @@ const MR = class MCSRouter {
 
       clients.forEach(client => {
         client.mediaState(mediaId, state);
-      })
+      });
     });
 
     this.emitter.on(C.EVENT.ROOM_CREATED, ({ id }) => {
       const clients = this._getClientToDispatch('all', C.EVENT.ROOM_CREATED);
-
       Logger.trace('[mcs-router] Room created event', id);
-
       clients.forEach(client => {
         client.roomCreated(id);
-      })
+      });
     });
 
     this.emitter.on(C.EVENT.ROOM_DESTROYED, ({ roomId }) => {
       const clients = this._getClientToDispatch(roomId, C.EVENT.ROOM_DESTROYED);
-
+      this._removeEventFromClientEventMap(roomId, C.EVENT.MEDIA_CONNECTED);
+      this._removeEventFromClientEventMap(roomId, C.EVENT.USER_JOINED);
+      this._removeEventFromClientEventMap(roomId, C.EVENT.USER_LEFT);
+      this._removeEventFromClientEventMap(roomId, C.EVENT.ROOM_DESTROYED);
+      this._removeEventFromClientEventMap(roomId, C.EVENT.CONTENT_FLOOR_CHANGED);
+      this._removeEventFromClientEventMap(roomId, C.EVENT.CONFERENCE_FLOOR_CHANGED);
       Logger.trace('[mcs-router] Room destroyed event', roomId);
-
-      this._removeFromClientEventMap(roomId, C.EVENT.MEDIA_CONNECTED);
-      this._removeFromClientEventMap(roomId, C.EVENT.USER_JOINED);
-      this._removeFromClientEventMap(roomId, C.EVENT.USER_LEFT);
-
       clients.forEach(client => {
         client.roomDestroyed(roomId);
-      })
+      });
     });
 
     this.emitter.on(C.EVENT.MEDIA_CONNECTED, event => {
@@ -839,9 +852,16 @@ const MR = class MCSRouter {
     this.emitter.on(C.EVENT.MEDIA_DISCONNECTED, event => {
       const { roomId, mediaId } = event;
       const clients = this._getClientToDispatch(mediaId, C.EVENT.MEDIA_DISCONNECTED);
-      this._removeFromClientEventMap(mediaId, C.EMAP[C.EVENT.MEDIA_STATE.MEDIA_EVENT]);
-      this._removeFromClientEventMap(mediaId, C.EMAP[C.EVENT.MEDIA_STATE.ICE]);
-
+      this._removeEventFromClientEventMap(mediaId, C.EMAP[C.EVENT.MEDIA_STATE.MEDIA_EVENT]);
+      this._removeEventFromClientEventMap(mediaId, C.EMAP[C.EVENT.MEDIA_STATE.ICE]);
+      this._removeEventFromClientEventMap(mediaId, C.EVENT.MEDIA_DISCONNECTED);
+      this._removeEventFromClientEventMap(mediaId, C.EVENT.MEDIA_VOLUME_CHANGED);
+      this._removeEventFromClientEventMap(mediaId, C.EVENT.MEDIA_START_TALKING);
+      this._removeEventFromClientEventMap(mediaId, C.EVENT.MEDIA_STOP_TALKING);
+      this._removeEventFromClientEventMap(mediaId, C.EVENT.MEDIA_MUTED);
+      this._removeEventFromClientEventMap(mediaId, C.EVENT.MEDIA_UNMUTED);
+      this._removeEventFromClientEventMap(mediaId, C.EVENT.KEYFRAME_NEEDED);
+      this._removeEventFromClientEventMap(mediaId, C.EVENT.SUBSCRIBED_TO);
       clients.forEach(client => {
         Logger.trace('[mcs-router] Emitting media disconnected for', mediaId, "at client", client.trackingId);
         client.mediaDisconnected(roomId, mediaId);
@@ -863,7 +883,7 @@ const MR = class MCSRouter {
 
       clients.forEach(client => {
         client.userLeft(roomId, userId);
-      })
+      });
     });
 
     this.emitter.on(C.EVENT.CONTENT_FLOOR_CHANGED, event => {


### PR DESCRIPTION
Also fixed a quirk with kurento's adapter `generateOffer` pre-filters leaving blank lines in the SDP.