### PR TITLE
Implement media thresholds (#123)

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -166,8 +166,22 @@ kurentoRembParams:
   upLosses: 12
   decrementFactor: 0.5
   thresholdFactor: 0.8
-# Optional configuration. List of VALID IPs to be used to define valid outbound ICE candidates.
-# This is a short-term optimization to reduce the number of candidate sent to
+# kurentoAllowedCandidateIps: optional configuration. List of VALID IPs to be used 
+# to define valid outbound ICE candidates.
+# This is a short-term optimization to reduce the number of candidates sent to
 # the client by filtering out anything that isn't in this list
 kurentoAllowedCandidateIps:
   #- <ipv4|ipv6>
+
+# mediaThresholds: mandatory configuration. Establishes type-agnostic media thresholds 
+# that when hit will make the server refuse to negotiate new medias. 
+# Any attemps to inject medias past the thresholds will return an error with code 
+# 2002 and message MEDIA_SERVER_NO_RESOURCES.
+# The threshold priority order is global -> perRoom -> perUser. Value 0 means unlimited
+# (default). An optional API parameter may be sent on pub/sub calls (ignoreThresholds)
+# to make the media ignore the configured thresholds. This is used here for recording
+# and audio medias.
+mediaThresholds:
+  global: 0
+  perRoom: 0
+  perUser: 0

--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -227,6 +227,7 @@ module.exports = class Audio extends BaseProvider {
           const globalAudioOptions = {
             adapter: 'Freeswitch',
             name: calleeName,
+            ignoreThresholds: true,
           }
 
           // Publish with server acting as offeree. Answer is here is actually the
@@ -245,6 +246,7 @@ module.exports = class Audio extends BaseProvider {
             adapter: 'Kurento',
             descriptor: answer,
             name: `PROXY_${calleeName}|subscribe`,
+            ignoreThresholds: true,
           }
 
           const { mediaId: proxyId, answer: proxyAnswer } = await this.mcs.subscribe(
@@ -309,6 +311,7 @@ module.exports = class Audio extends BaseProvider {
             descriptor: sdpOffer,
             adapter: 'Kurento',
             name: this._assembleStreamName('subscribe', userId, this.meetingId),
+            ignoreThresholds: true,
           }
 
           const { mediaId, answer } = await this.mcs.subscribe(mcsUserId,

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -11,6 +11,7 @@ const Balancer = require('./balancer');
 const AdapterFactory = require('../adapters/adapter-factory');
 const StrategyManager = require('./strategy-manager.js');
 const MediaFactory = require('./media-factory.js');
+const { global: GLOBAL_MEDIA_THRESHOLD } = config.get('mediaThresholds');
 
 const LOG_PREFIX = "[mcs-controller]";
 
@@ -102,6 +103,7 @@ module.exports = class MediaController {
         killedMedias.forEach((mediaId) => {
           try {
             this.removeMediaSession(mediaId);
+            room.removeMediaSession(mediaId);
           } catch (e) {
             // Media was probably not found, just log it here and go on
             this._handleError(e);
@@ -142,18 +144,42 @@ module.exports = class MediaController {
     return Promise.resolve();
   }
 
+  _isAboveThreshold () {
+    if (GLOBAL_MEDIA_THRESHOLD > 0 && this.medias.length >= GLOBAL_MEDIA_THRESHOLD) {
+      Logger.error(LOG_PREFIX, `Server has exceeded the media threshold`,
+        { threshold: GLOBAL_MEDIA_THRESHOLD, current: this.medias.length}
+      );
+      return true;
+    }
+    return false;
+  }
+
+  isAboveMediaThresholds (room, user) {
+    if (this._isAboveThreshold() ||
+      room.isAboveThreshold() ||
+      user.isAboveThreshold()) {
+      return true;
+    }
+    return false;
+  }
+
   publishAndSubscribe (roomId, userId, sourceId, type, params = {}) {
     return new Promise(async (resolve, reject) => {
       Logger.info(LOG_PREFIX, `PublishAndSubscribe from user ${userId} to source ${sourceId}`);
       Logger.trace("[mcs-controler] PublishAndSubscribe descriptor is", params.descriptor);
 
       try {
+        let source;
+        type = C.EMAP[type];
         const user = await this.getUser(userId);
         const room = await this.getRoom(user.roomId);
 
-        let source;
-
-        type = C.EMAP[type];
+        if (!params.ignoreThresholds && this.isAboveMediaThresholds(room, user)) {
+          return reject(this._handleError({
+            ...C.ERROR.MEDIA_SERVER_NO_RESOURCES,
+            details: `Threshold exceeded. Threshold: ${GLOBAL_MEDIA_THRESHOLD}`,
+          }));
+        }
 
         switch (type) {
           case C.MEDIA_TYPE.RTP:
@@ -187,8 +213,14 @@ module.exports = class MediaController {
       try {
         const user = await this.getUser(userId);
         const room = await this.getRoom(user.roomId);
-
         type = C.EMAP[type];
+
+        if (!params.ignoreThresholds && this.isAboveMediaThresholds(room, user)) {
+          return reject(this._handleError({
+            ...C.ERROR.MEDIA_SERVER_NO_RESOURCES,
+            details: `Threshold exceeded. Threshold: ${GLOBAL_MEDIA_THRESHOLD}`,
+          }));
+        }
 
         switch (type) {
           case C.MEDIA_TYPE.RTP:
@@ -216,6 +248,7 @@ module.exports = class MediaController {
       Logger.info(LOG_PREFIX, `Subscribe from user ${userId} to source ${sourceId}`);
       Logger.trace(LOG_PREFIX, "Subscribe descriptor is", params.descriptor);
       let source, user, room;
+      type = C.EMAP[type];
 
       try {
         user = await this.getUser(userId);
@@ -230,7 +263,12 @@ module.exports = class MediaController {
         return reject(this._handleError(e));
       }
 
-      type = C.EMAP[type];
+      if (!params.ignoreThresholds && this.isAboveMediaThresholds(room, user)) {
+        return reject(this._handleError({
+          ...C.ERROR.MEDIA_SERVER_NO_RESOURCES,
+          details: `Threshold exceeded. Threshold: ${GLOBAL_MEDIA_THRESHOLD}`,
+        }));
+      }
 
       switch (type) {
         case C.MEDIA_TYPE.RTP:

--- a/lib/mcs-core/lib/model/room.js
+++ b/lib/mcs-core/lib/model/room.js
@@ -5,10 +5,12 @@
 
 'use strict'
 
+const config = require('config');
 const C = require('../constants/constants');
 const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
 const Logger = require('../utils/logger');
 const StrategyManager = require('../media/strategy-manager.js');
+const { perRoom: ROOM_MEDIA_THRESHOLD } = config.get('mediaThresholds');
 
 const LOG_PREFIX = "[mcs-room]";
 const MAX_PREVIOUS_FLOORS = 10;
@@ -59,6 +61,16 @@ module.exports = class Room {
     return Object.keys(this.users).map(uk => this.users[uk].getUserInfo());
   }
 
+  isAboveThreshold () {
+    if (ROOM_MEDIA_THRESHOLD > 0 && this.medias.length >= ROOM_MEDIA_THRESHOLD) {
+      Logger.error(LOG_PREFIX, `Room has exceeded the media threshold`,
+        { roomId: this.id, threshold: ROOM_MEDIA_THRESHOLD, current: this.medias.length}
+      );
+      return true;
+    }
+    return false;
+  }
+
   addUser (user) {
     const found = user.id in this.users;
     if (!found) {
@@ -75,8 +87,8 @@ module.exports = class Room {
     this.medias.find(m => m.id === mediaId);
   }
 
-  removeMedia (mediaId) {
-    this.medias = this.medias.filter(m => m.id !== mediaId);
+  removeMedia ({ id }) {
+    this.medias = this.medias.filter(media => media.id !== id);
   }
 
   addMediaSession (mediaSession) {
@@ -102,8 +114,8 @@ module.exports = class Room {
 
   removeMediaSession (mediaSessionId) {
     const mediaSession = this.getMediaSession(mediaSessionId);
-    this.mediaSessions = this.mediaSessions.filter(ms => ms.id !== mediaSessionId);
     mediaSession.medias.forEach(this.removeMedia.bind(this));
+    this.mediaSessions = this.mediaSessions.filter(ms => ms.id !== mediaSessionId);
   }
 
   getConferenceFloor () {

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-
+const config = require('config');
 const rid = require('readable-id');
 const C = require('../constants/constants.js');
 const Logger = require('../utils/logger.js');
@@ -13,6 +13,7 @@ const MediaFactory = require('../media/media-factory.js');
 const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
 const { handleError } = require('../utils/util.js');
 const StrategyManager = require('../media/strategy-manager.js');
+const { perUser: USER_MEDIA_THRESHOLD } = config.get('mediaThresholds');
 
 const LOG_PREFIX = "[mcs-user]";
 
@@ -81,6 +82,22 @@ module.exports = class User {
         return reject(this._handleError(err));
       }
     });
+  }
+
+  isAboveThreshold () {
+    if (USER_MEDIA_THRESHOLD > 0) {
+      const nofMediaUnits = Object.keys(this.mediaSessions).map(key => {
+        let mi = this.mediaSessions[key].getMediaInfo();
+        return mi;
+      }).length;
+      if (nofMediaUnits >= USER_MEDIA_THRESHOLD) {
+        Logger.error(LOG_PREFIX, `User has exceeded the media threshold`,
+          { userId: this.id, threshold: USER_MEDIA_THRESHOLD, current: nofMediaUnits }
+        );
+        return true;
+      }
+    }
+    return false;
   }
 
   createMediaSession (descriptor, type, params = {}) {
@@ -190,7 +207,6 @@ module.exports = class User {
     params.sourceMedia = source;
     const recordingSession = this.createMediaSession(recordingPath, type, params);
     const answer = await this.startSession(recordingSession.id);
-
     return ({ recordingSession, answer });
   }
 

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -233,7 +233,7 @@ module.exports = class Screenshare extends BaseProvider {
           this.presenterMCSUserId,
           this._presenterEndpoint,
           recordingPath,
-          { recordingProfile }
+          { recordingProfile, ignoreThresholds: true }
         );
         this.recording = { recordingId, filename: recordingPath };
         this.mcs.onEvent(C.MEDIA_STATE, this.recording.recordingId, (event) => {

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -236,7 +236,7 @@ module.exports = class Video extends BaseProvider {
           this.userId,
           this.mediaId,
           recordingPath,
-          { recordingProfile }
+          { recordingProfile, ignoreThresholds: true }
         );
 
         this.mcs.onEvent(C.MEDIA_STATE, recordingId, (event) => {


### PR DESCRIPTION
Implements #123.
- Audio and recording medias are ignored in the threshold accounting for now (`ignoreThresholds: true` optional parameter).
- Unlimited by default.
- The limits are content type agnostic.

Also took the time to fix a small leak in `Room`'s media unit removal.