### PR TITLE
[mcs-core] Properly log stack traces, make removeSessionDescription static

### DIFF
--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -1033,8 +1033,6 @@ module.exports = class Kurento extends EventEmitter {
     let { message: oldMessage , code, stack } = err;
     let message;
 
-    Logger.trace(LOG_PREFIX, 'Error stack', err);
-
     if (code && code >= C.ERROR.MIN_CODE && code <= C.ERROR.MAX_CODE) {
       return err;
     }
@@ -1069,7 +1067,11 @@ module.exports = class Kurento extends EventEmitter {
     err.details = oldMessage;
     err.stack = stack
 
-    Logger.debug(LOG_PREFIX, 'Media Server returned an', err.code, err.message);
+    if (stack && !err.stackWasLogged)  {
+      Logger.error(LOG_PREFIX, `Stack trace for error ${err.code} | ${err.message} ->`,
+        { errorStack: err.stack.toString() });
+      err.stackWasLogged = true;
+    }
     return err;
   }
 };

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -247,7 +247,7 @@ module.exports = class SDPSession extends MediaSession {
           try {
             const audioMedia = this.medias.find(m => m.mediaTypes.audio);
             Logger.info(LOG_PREFIX, `Processing answerer audio streams for session ${this.id} at media ${audioMedia.id}: ${this.remoteDescriptor.audioSdp}`);
-            const adescBody = this.remoteDescriptor.removeSessionDescription(this.remoteDescriptor.audioSdp);
+            const adescBody = SdpWrapper.removeSessionDescription(this.remoteDescriptor.audioSdp);
             const mainWithInvalidVideo = this.remoteDescriptor.sessionDescriptionHeader + adescBody;
             await audioAdapter.processAnswer(audioMedia.adapterElementId, mainWithInvalidVideo);
             audioMedia.remoteDescriptor = this.remoteDescriptor.audioSdp;
@@ -409,13 +409,13 @@ module.exports = class SDPSession extends MediaSession {
     }
 
     if (headDescription && headDescription[0]) {
-      body += headDescription[0].localDescriptor.removeSessionDescription(headDescription[0].localDescriptor._plainSdp);
+      body += SdpWrapper.removeSessionDescription(headDescription[0].localDescriptor._plainSdp);
     }
 
     remainingDescriptions.forEach(m => {
       const partialLocalDescriptor = m.localDescriptor;
       if (partialLocalDescriptor) {
-        body += partialLocalDescriptor.removeSessionDescription(partialLocalDescriptor._plainSdp)
+        body += SdpWrapper.removeSessionDescription(partialLocalDescriptor._plainSdp)
       }
     });
 

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -165,7 +165,13 @@ module.exports = class SdpWrapper {
     return sdp.match(/[\s\S]+?(?=m=audio|m=video)/i);
   }
 
-  removeSessionDescription (sdp) {
+  /**
+   * Given a SDP, strip the session description header from it and return the rest
+   * (or undefined if theres no m=* lines on it);
+   * @param  {String} sdp The Session Descriptor
+   * @return {String} a SDP stripped of its header (m=* lines only)
+   */
+  static removeSessionDescription (sdp) {
     const sd = sdp.match(/(?=[\s\S]+?)(m=audio[\s\S]+|m=video[\s\S]+)/i);
     return sd? sd[1] : undefined;
   }

--- a/lib/mcs-core/lib/utils/util.js
+++ b/lib/mcs-core/lib/utils/util.js
@@ -16,8 +16,6 @@ exports.isError = (error) => {
 exports.handleError = (logPrefix, error) => {
   let { message, code, stack, data, details } = error;
 
-  Logger.trace(logPrefix, "Error stack", error);
-
   if (code && code >= C.ERROR.MIN_CODE && code <= C.ERROR.MAX_CODE) {
     return error;
   }
@@ -44,7 +42,11 @@ exports.handleError = (logPrefix, error) => {
     error.details = message;
   }
 
-  Logger.debug(logPrefix, "Handling error", error.code, error.message);
+  if (stack && !error.stackWasLogged)  {
+    Logger.error(logPrefix, `Stack trace for error ${error.code} | ${error.message} ->`,
+      { errorStack: error.stack.toString() });
+    error.stackWasLogged = true;
+  }
 
   return error;
 }


### PR DESCRIPTION
  - Stack traces are now properly logged in the error handlers with the `error` log level and just once.
  - `SdpWrapper#removeSessionDescription` method made static