### PR TITLE
Addresses #139

### DIFF
--- a/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
+++ b/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
@@ -214,7 +214,7 @@ module.exports = class Freeswitch extends EventEmitter {
 
   async _negotiateSDPEndpoint (roomId, userId, mediaSessionId, descriptor, type, options) {
     let mediaElement, host;
-    Logger.debug(LOG_PREFIX,"Negotiating SDP endpoint for", userId, "at", roomId);
+    Logger.debug(LOG_PREFIX, `Negotiating SDP endpoint for ${userId} at ${roomId}`);
     try {
       ({ mediaElement, host } = await this.createMediaElement(roomId, type, options));
       const answer = await this.processOffer(mediaElement, descriptor, options);
@@ -691,7 +691,8 @@ module.exports = class Freeswitch extends EventEmitter {
   _createUserAgent (type, displayName, roomId) {
     const uriUser = displayName ? displayName : roomId;
     const newUA = new SIPJS.UA({
-      uri: `sip:${uriUser}@${FREESWITCH_IP}`,
+
+      uri: `sip:${encodeURIComponent(uriUser)}@${FREESWITCH_IP}`,
       wsServers: `ws://${FREESWITCH_IP}:${FREESWITCH_PORT}`,
       displayName: displayName,
       register: false,

--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -213,7 +213,7 @@ module.exports = class Kurento extends EventEmitter {
     try {
       // We strip the SDP into media units of the same type because Kurento can't handle
       // bundling other than audio + video
-      const partialDescriptors = SdpWrapper.getSupportedPartialDescriptions(descriptor, this.supportedCodecs);
+      const partialDescriptors = SdpWrapper.getPartialDescriptions(descriptor);
       let medias = []
       const negotiationProcedures = partialDescriptors.map((d, i) => {
         return new Promise(async (resolve, reject) => {

--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -191,7 +191,7 @@ module.exports = class Kurento extends EventEmitter {
     }
   }
 
-  _appendContentTypeIfNeeded (descriptor, mediaType) {
+  static appendContentTypeIfNeeded (descriptor, mediaType) {
     // Check if we need to add :main or :slides
     // Since Kurento still does not treat a=content:x lines well, we
     // reappend it here manually to work around the issue
@@ -213,7 +213,7 @@ module.exports = class Kurento extends EventEmitter {
     try {
       // We strip the SDP into media units of the same type because Kurento can't handle
       // bundling other than audio + video
-      const partialDescriptors = SdpWrapper.getPartialDescriptions(descriptor);
+      const partialDescriptors = SdpWrapper.getSupportedPartialDescriptions(descriptor, this.supportedCodecs);
       let medias = []
       const negotiationProcedures = partialDescriptors.map((d, i) => {
         return new Promise(async (resolve, reject) => {
@@ -245,7 +245,7 @@ module.exports = class Kurento extends EventEmitter {
               answer = await this.generateOffer(mediaElement, filterOptions);
             }
 
-            answer = this._appendContentTypeIfNeeded(answer, mediaType);
+            answer = Kurento.appendContentTypeIfNeeded(answer, mediaType);
 
             // Just do a late-set of the properties that were nullified in the early
             // media instantiation

--- a/lib/mcs-core/lib/constants/constants.js
+++ b/lib/mcs-core/lib/constants/constants.js
@@ -28,6 +28,7 @@ exports.MEDIA_TYPE.WEBRTC = "WebRtcEndpoint"
 exports.MEDIA_TYPE.RTP = "RtpEndpoint"
 exports.MEDIA_TYPE.URI = "PlayerEndpoint"
 exports.MEDIA_TYPE.RECORDING = "RecorderEndpoint"
+exports.MEDIA_TYPE.INTERNAL_UNSUPPORTED = "InternalUnsupportedMedia"
 
 exports.MEDIA_PROFILE = {}
 exports.MEDIA_PROFILE.MAIN = 'main'

--- a/lib/mcs-core/lib/constants/constants.js
+++ b/lib/mcs-core/lib/constants/constants.js
@@ -33,6 +33,8 @@ exports.MEDIA_PROFILE = {}
 exports.MEDIA_PROFILE.MAIN = 'main'
 exports.MEDIA_PROFILE.CONTENT = 'content'
 exports.MEDIA_PROFILE.AUDIO = 'audio'
+exports.MEDIA_PROFILE.APPLICATION = 'application'
+exports.MEDIA_PROFILE.UNSUPPORTED = 'unsupported'
 exports.MEDIA_PROFILE.ALL = 'all'
 
 exports.CONNECTION_TYPE = {}

--- a/lib/mcs-core/lib/model/int-unsupported-media.js
+++ b/lib/mcs-core/lib/model/int-unsupported-media.js
@@ -4,7 +4,7 @@ const rid = require('readable-id');
 const Media = require('./media');
 const config = require('config');
 const Logger = require('../utils/logger');
-const LOG_PREFIX = "[mcs-sdp-media]";
+const LOG_PREFIX = "[mcs-internal-unsupported-media]";
 
 module.exports = class InternalUnsupportedMedia extends Media {
   constructor(

--- a/lib/mcs-core/lib/model/int-unsupported-media.js
+++ b/lib/mcs-core/lib/model/int-unsupported-media.js
@@ -48,7 +48,7 @@ module.exports = class InternalUnsupportedMedia extends Media {
       this._localDescriptor = new SdpWrapper(
         localDescriptor,
         C.DEFAULT_MEDIA_SPECS,
-        C.MEDIA_PROFILE.UNSUPPORTED,
+        C.MEDIA_PROFILE.INTERNAL_UNSUPPORTED,
         { preProcess: false }
       );
     }

--- a/lib/mcs-core/lib/model/int-unsupported-media.js
+++ b/lib/mcs-core/lib/model/int-unsupported-media.js
@@ -34,7 +34,6 @@ module.exports = class InternalUnsupportedMedia extends Media {
         C.MEDIA_PROFILE.INTERNAL_UNSUPPORTED,
         { preProcess: false }
       );
-
       this.localDescriptor = this.remoteDescriptor.generateInactiveDescriptor();
     }
   }

--- a/lib/mcs-core/lib/model/int-unsupported-media.js
+++ b/lib/mcs-core/lib/model/int-unsupported-media.js
@@ -1,0 +1,60 @@
+const C = require('../constants/constants');
+const SdpWrapper = require('../utils/sdp-wrapper');
+const rid = require('readable-id');
+const Media = require('./media');
+const config = require('config');
+const Logger = require('../utils/logger');
+const LOG_PREFIX = "[mcs-sdp-media]";
+
+module.exports = class InternalUnsupportedMedia extends Media {
+  constructor(
+    room,
+    user,
+    mediaSessionId,
+    remoteDescriptor,
+    type
+  ) {
+    super(room, user, mediaSessionId, type, null, null, null, {});
+    // {SdpWrapper} SdpWrapper
+    this._remoteDescriptor;
+    this._localDescriptor;
+
+    if (remoteDescriptor) {
+      this.remoteDescriptor = remoteDescriptor;
+    }
+
+    Logger.info(LOG_PREFIX,  "New media created", JSON.stringify(this.getMediaInfo()));
+  }
+
+  set remoteDescriptor (remoteDescriptor) {
+    if (remoteDescriptor) {
+      this._remoteDescriptor = new SdpWrapper(
+        remoteDescriptor,
+        C.DEFAULT_MEDIA_SPECS,
+        C.MEDIA_PROFILE.INTERNAL_UNSUPPORTED,
+        { preProcess: false }
+      );
+
+      this.localDescriptor = this.remoteDescriptor.generateInactiveDescriptor();
+    }
+  }
+
+  get remoteDescriptor () {
+    return this._remoteDescriptor;
+  }
+
+  set localDescriptor (localDescriptor) {
+    if (localDescriptor) {
+      this._localDescriptor = new SdpWrapper(
+        localDescriptor,
+        C.DEFAULT_MEDIA_SPECS,
+        C.MEDIA_PROFILE.UNSUPPORTED,
+        { preProcess: false }
+      );
+    }
+  }
+
+  get localDescriptor () {
+    return this._localDescriptor;
+  }
+}

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -76,6 +76,7 @@ module.exports = class MediaSession {
     // Array of media sessions that are subscribed to this feed
     this.subscribedSessions = [];
     this.medias = [];
+    this.invalidMedias = [];
     // An object that describes the capabilities of this media session
     this.mediaTypes = {
       video: false,

--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -159,6 +159,11 @@ module.exports = class Media {
         Logger.info(LOG_PREFIX, "Session", this.id, "stopped with status", this.status);
 
         GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, this.getMediaInfo());
+        // FIXME this is a workaround to also notify listeners hooked only to mediaSessionId
+        // of a child media unit getting disconnected.
+        const mediaInfo = this.getMediaInfo();
+        mediaInfo.mediaId = this.mediaSessionId;
+        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, mediaInfo);
 
         Balancer.removeListener(C.EVENT.MEDIA_SERVER_OFFLINE, this.onHostOffline);
         Balancer.removeListener(C.EVENT.MEDIA_SERVER_ONLINE, this.onHostOnline);

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -10,6 +10,7 @@ const SdpWrapper = require('../utils/sdp-wrapper');
 const rid = require('readable-id');
 const MediaSession = require('./media-session');
 const SDPMedia = require('./sdp-media');
+const InternalUnsupportedMedia = require('./int-unsupported-media.js');
 const config = require('config');
 const Logger = require('../utils/logger');
 const AdapterFactory = require('../adapters/adapter-factory');
@@ -183,12 +184,18 @@ module.exports = class SDPSession extends MediaSession {
   }
 
   async _negotiateApplicationMedias (descriptor) {
-    return this._rejectMedia(descriptor);
+    return this._rejectMedias(descriptor);
   };
 
-  // TODO this is a stub
-  async _rejectMedia (descriptor) {
-    return [];
+  async _rejectMedias (descriptor) {
+    const unsupportedMediaContainer = new InternalUnsupportedMedia(
+      this.roomId,
+      this.userId,
+      this.id,
+      descriptor,
+      C.MEDIA_TYPE.INTERNAL_UNSUPPORTED,
+    );
+    return [unsupportedMediaContainer];
   };
 
   async _composedAdapterProcess () {
@@ -198,7 +205,7 @@ module.exports = class SDPSession extends MediaSession {
       [C.MEDIA_PROFILE.MAIN]: this._negotiateVideoMedias.bind(this),
       [C.MEDIA_PROFILE.CONTENT]: this._negotiateContentMedias.bind(this),
       [C.MEDIA_PROFILE.APPLICATION]: this._negotiateApplicationMedias.bind(this),
-      [C.MEDIA_PROFILE.UNSUPPORTED]: this._rejectMedia.bind(this),
+      [C.MEDIA_PROFILE.UNSUPPORTED]: this._rejectMedias.bind(this),
     };
 
     return Object.keys(annotatedPartialDescriptors).reduce((promise, type) => {
@@ -208,7 +215,11 @@ module.exports = class SDPSession extends MediaSession {
           .then(processedMedias => {
             processedMedias.forEach((mediaUnit, adapterIndex) => {
               const sdpPosition = indexes[adapterIndex]
-              this.medias[sdpPosition] = mediaUnit;
+              if (mediaUnit.type !== C.MEDIA_TYPE.INTERNAL_UNSUPPORTED) {
+                this.medias[sdpPosition] = mediaUnit;
+              } else {
+                this.invalidMedias[sdpPosition] = mediaUnit;
+              }
             })
           })
           .catch(error => {
@@ -402,26 +413,21 @@ module.exports = class SDPSession extends MediaSession {
 
   getAnswer () {
     let header = '', body = '';
+    let mediasToProcess = [];
+    this.medias.forEach((m, i) => {
+      mediasToProcess[i] = m;
+    });
+    this.invalidMedias.forEach((m, i) => {
+      mediasToProcess[i] = m;
+    });
+    mediasToProcess = mediasToProcess.filter(m => m);
+    const validMedia = mediasToProcess.find(m => m.type !== C.MEDIA_TYPE.INTERNAL_UNSUPPORTED);
 
-    // Some endpoints demand that the audio description be first in order to work
-    // FIXME this should be reviewed. The m= lines  order should match the
-    // offer order, otherwise the Unified Plan partisans will complain
-    const headDescription = this.medias.filter(m => m.mediaTypes.audio);
-    const remainingDescriptions = this.medias.filter(m => !m.mediaTypes.audio);
+    // TODO review this early exit
+    if (!validMedia) return;
 
-    if (remainingDescriptions && remainingDescriptions[0]) {
-      header = remainingDescriptions[0].localDescriptor.sessionDescriptionHeader;
-    } else  if (this.medias[0]) {
-      header = this.medias[0].localDescriptor.sessionDescriptionHeader;
-    } else {
-      return;
-    }
-
-    if (headDescription && headDescription[0]) {
-      body += SdpWrapper.removeSessionDescription(headDescription[0].localDescriptor._plainSdp);
-    }
-
-    remainingDescriptions.forEach(m => {
+    header = validMedia.localDescriptor.sessionDescriptionHeader;
+    mediasToProcess.forEach(m => {
       const partialLocalDescriptor = m.localDescriptor;
       if (partialLocalDescriptor) {
         body += SdpWrapper.removeSessionDescription(partialLocalDescriptor._plainSdp)

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -97,7 +97,7 @@ module.exports = class SDPSession extends MediaSession {
     return this._localDescriptor;
   }
 
-  async _negotiateAudioMedias (descriptor = null) {
+  async _negotiateAudioMedias (descriptor = '') {
     Logger.debug(LOG_PREFIX, `Composed adapter negotiation for audio medias requested at session ${this.id}`, { descriptor } );
     const { audioAdapter } = this._adapters;
     // If descriptor comes in null, we're the offerer.
@@ -111,7 +111,7 @@ module.exports = class SDPSession extends MediaSession {
     const audioOptions = isAnswerer ?
       this._options :
       { ...this._options, mediaProfile: C.MEDIA_PROFILE.AUDIO };
-    if (this.profiles.audio || descriptor) {
+    if (this.profiles.audio || !!descriptor) {
       try {
         const audioMedias = await audioAdapter.negotiate(
           this.roomId, this.userId, this.id,
@@ -130,7 +130,7 @@ module.exports = class SDPSession extends MediaSession {
     }
   }
 
-  async _negotiateVideoMedias (descriptor) {
+  async _negotiateVideoMedias (descriptor = '') {
     Logger.debug(LOG_PREFIX, `Composed adapter negotiation for video medias requested at session ${this.id}`, { descriptor } );
     const { videoAdapter } = this._adapters;
     const isAnswerer = this.negotiationRole === C.NEGOTIATION_ROLE.ANSWERER;
@@ -138,7 +138,7 @@ module.exports = class SDPSession extends MediaSession {
       this._options :
       { ...this._options, mediaProfile: C.MEDIA_PROFILE.MAIN };
 
-    if (this.profiles.video || descriptor) {
+    if (this.profiles.video || !!descriptor) {
       try {
         const videoMedias = await videoAdapter.negotiate(
           this.roomId, this.userId, this.id,
@@ -157,14 +157,14 @@ module.exports = class SDPSession extends MediaSession {
     }
   }
 
-  async _negotiateContentMedias (descriptor) {
+  async _negotiateContentMedias (descriptor = '') {
     Logger.debug(LOG_PREFIX, `Composed adapter negotiation for content medias requested at session ${this.id}`, { descriptor } );
     const { contentAdapter } = this._adapters;
     const isAnswerer = this.negotiationRole === C.NEGOTIATION_ROLE.ANSWERER;
     const contentOptions = isAnswerer ?
       this._options :
       { ...this._options, mediaProfile: C.MEDIA_PROFILE.CONTENT };
-    if (this.profiles.content || descriptor) {
+    if (this.profiles.content || !!descriptor) {
       try {
         const contentMedias = await contentAdapter.negotiate(
           this.roomId, this.userId, this.id, descriptor,
@@ -187,7 +187,10 @@ module.exports = class SDPSession extends MediaSession {
     return this._rejectMedias(descriptor);
   };
 
-  async _rejectMedias (descriptor) {
+  async _rejectMedias (descriptor = '') {
+    if (!descriptor) {
+      return [];
+    }
     const unsupportedMediaContainer = new InternalUnsupportedMedia(
       this.roomId,
       this.userId,
@@ -199,7 +202,13 @@ module.exports = class SDPSession extends MediaSession {
   };
 
   async _composedAdapterProcess () {
-    const annotatedPartialDescriptors = SdpWrapper.getAnnotatedPartialDescriptors(this.remoteDescriptor._plainSdp);
+    const remoteDescriptor = this.remoteDescriptor
+      ? this.remoteDescriptor._plainSdp
+      : '';
+    let {
+      numberOfMediaLines,
+      annotatedDescriptors: annotatedPartialDescriptors,
+    } = SdpWrapper.getAnnotatedPartialDescriptors(remoteDescriptor);
     const processMethods = {
       [C.MEDIA_PROFILE.AUDIO]: this._negotiateAudioMedias.bind(this),
       [C.MEDIA_PROFILE.MAIN]: this._negotiateVideoMedias.bind(this),
@@ -214,28 +223,61 @@ module.exports = class SDPSession extends MediaSession {
         return processMethods[type](descriptor)
           .then(processedMedias => {
             processedMedias.forEach((mediaUnit, adapterIndex) => {
-              const sdpPosition = indexes[adapterIndex]
-              if (mediaUnit.type !== C.MEDIA_TYPE.INTERNAL_UNSUPPORTED) {
-                this.medias[sdpPosition] = mediaUnit;
+              let sdpPosition;
+              // if block: we have a mapping of the partial descriptor indexes to the adapter
+              // processing index. Keep in mind that the indexes array returned
+              // in the annotatedDescriptorEntry is the overall position of then
+              // m=* line in the ENTIRE REMOTE DESCRIPTOR. The adapters MUST
+              // process m=* lines in order if they need to do so separately,
+              // so the adapterIndex should server as the correct index to fetch
+              // the original SDP position in indexes
+              if (typeof indexes[adapterIndex] !== 'undefined') {
+                sdpPosition = indexes[adapterIndex];
               } else {
-                this.invalidMedias[sdpPosition] = mediaUnit;
+                // else block: we don't have a mapping. This means this is a new
+                // media from US as the OFFERERS. The position will be right after
+                // the LAST processed media indicated by the numberOfMediaLines
+                // (or 0).
+                sdpPosition = numberOfMediaLines;
+                numberOfMediaLines = numberOfMediaLines += 1;
               }
-            })
+              mediaUnit.sdpPosition = sdpPosition;
+              if (mediaUnit.type !== C.MEDIA_TYPE.INTERNAL_UNSUPPORTED) {
+                this.medias.push(mediaUnit);
+              } else {
+                this.invalidMedias.push(mediaUnit);
+              }
+            });
           })
           .catch(error => {
+            // TODO would be cool to deactivate medias that failed to be negotiated
+            // if they were from a negotiation from the remote end.
             Logger.error(LOG_PREFIX, `Failed to negotiate ${type} medias, none will be generated due to ${error.message}`,
               { error: this._handleError(error) });
         });
       });
     }, Promise.resolve()).then(() => {
       Logger.info(LOG_PREFIX, `Composed adapter processing finished for ${this.id}`);
-    });
+    }).catch(error => {
+      const normalizedError = this._handleError(error);
+      Logger.error(LOG_PREFIX, `Composed adapter process error on promise chain ${error.message}`,
+        { error: normalizedError });
+    });;
   }
 
   _monoAdapterProcess () {
     // The adapter is the same for all media types, so either one will suffice
     const remoteDescriptor = this.remoteDescriptor ? this.remoteDescriptor.plainSdp : null;
-    return this._adapters.videoAdapter.negotiate(this.roomId, this.userId, this.id, remoteDescriptor, this.type, this._options);
+    return this._adapters.videoAdapter.negotiate(this.roomId, this.userId, this.id, remoteDescriptor, this.type, this._options)
+      .then(medias => {
+        medias.forEach((m, index) => {
+          m.sdpPosition = index;
+        });
+        this.medias = this.medias.concat(medias);
+      })
+      .catch(error => {
+        throw error;
+      });
   }
 
   renegotiateStreams () {
@@ -289,6 +331,11 @@ module.exports = class SDPSession extends MediaSession {
             Logger.info(LOG_PREFIX, "Renegotiating content streams for", this.id, this.remoteDescriptor.contentVideoSdp);
             try {
               const contentMedias = await this._negotiateContentMedias();
+              let currentMediaLength = this.medias.length + this.invalidMedias.length;
+              contentMedias.forEach(cm => {
+                cm.sdpPosition = currentMediaLength
+                currentMediaLength +=1;
+              });
               this.medias = this.medias.concat(contentMedias);
             } catch (e) {
               this._handleError(e);
@@ -299,6 +346,11 @@ module.exports = class SDPSession extends MediaSession {
           try {
             try {
               const contentMedias = await this._negotiateContentMedias();
+              let currentMediaLength = this.medias.length + this.invalidMedias.length;
+              contentMedias.forEach(cm => {
+                cm.sdpPosition = currentMediaLength
+                currentMediaLength +=1;
+              });
               this.medias = this.medias.concat(contentMedias);
             } catch (e) {
               this._handleError(e);
@@ -414,11 +466,11 @@ module.exports = class SDPSession extends MediaSession {
   getAnswer () {
     let header = '', body = '';
     let mediasToProcess = [];
-    this.medias.forEach((m, i) => {
-      mediasToProcess[i] = m;
+    this.medias.forEach((m) => {
+      mediasToProcess[m.sdpPosition] = m;
     });
-    this.invalidMedias.forEach((m, i) => {
-      mediasToProcess[i] = m;
+    this.invalidMedias.forEach((m) => {
+      mediasToProcess[m.sdpPosition] = m;
     });
     mediasToProcess = mediasToProcess.filter(m => m);
     const validMedia = mediasToProcess.find(m => m.type !== C.MEDIA_TYPE.INTERNAL_UNSUPPORTED);

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -96,14 +96,13 @@ module.exports = class SDPSession extends MediaSession {
     return this._localDescriptor;
   }
 
-  async _negotiateAudioMedias () {
-    Logger.debug(LOG_PREFIX, `Composed adapter negotiation for audio medias requested at session ${this.id}`);
+  async _negotiateAudioMedias (descriptor = null) {
+    Logger.debug(LOG_PREFIX, `Composed adapter negotiation for audio medias requested at session ${this.id}`, { descriptor } );
     const { audioAdapter } = this._adapters;
-    // Check if we have a remote descriptor yet. If not, we're the offerer.
-    // In this case, the descriptor is just null and should be handled by the adapter
+    // If descriptor comes in null, we're the offerer.
+    // In this case, null should be handled by the adapter
     // as an indicator of offers needed to be generated.
     // Same thing goes for negotiateVideo/ContentMedias.
-    const audioDescription = this.remoteDescriptor? this.remoteDescriptor.audioSdp : null;
     // Set the media options according to the role we're performing. If we're the offerer,
     // we have to specify what're going to generate to the adapter manually.
     // Same thing goes for negotiateVideo/ContentMedias.
@@ -111,11 +110,11 @@ module.exports = class SDPSession extends MediaSession {
     const audioOptions = isAnswerer ?
       this._options :
       { ...this._options, mediaProfile: C.MEDIA_PROFILE.AUDIO };
-    if (this.profiles.audio || audioDescription) {
+    if (this.profiles.audio || descriptor) {
       try {
         const audioMedias = await audioAdapter.negotiate(
           this.roomId, this.userId, this.id,
-          audioDescription, this.type, audioOptions
+          descriptor, this.type, audioOptions
         );
         audioMedias.forEach(m => {
           m.localDescriptor = SdpWrapper.getAudioSDP(m.localDescriptor._plainSdp)
@@ -130,20 +129,19 @@ module.exports = class SDPSession extends MediaSession {
     }
   }
 
-  async _negotiateVideoMedias () {
-    Logger.debug(LOG_PREFIX, `Composed adapter negotiation for video medias requested at session ${this.id}`);
+  async _negotiateVideoMedias (descriptor) {
+    Logger.debug(LOG_PREFIX, `Composed adapter negotiation for video medias requested at session ${this.id}`, { descriptor } );
     const { videoAdapter } = this._adapters;
-    const videoDescription = this.remoteDescriptor? this.remoteDescriptor.mainVideoSdp : null;
     const isAnswerer = this.negotiationRole === C.NEGOTIATION_ROLE.ANSWERER;
     const videoOptions = isAnswerer ?
       this._options :
       { ...this._options, mediaProfile: C.MEDIA_PROFILE.MAIN };
 
-    if (this.profiles.video || videoDescription) {
+    if (this.profiles.video || descriptor) {
       try {
         const videoMedias = await videoAdapter.negotiate(
           this.roomId, this.userId, this.id,
-          videoDescription, this.type, videoOptions
+          descriptor, this.type, videoOptions
         );
         videoMedias.forEach(m => {
           m.localDescriptor =  SdpWrapper.getVideoSDP(m.localDescriptor._plainSdp);
@@ -158,18 +156,17 @@ module.exports = class SDPSession extends MediaSession {
     }
   }
 
-  async _negotiateContentMedias () {
-    Logger.debug(LOG_PREFIX, `Composed adapter negotiation for video medias requested at session ${this.id}`);
+  async _negotiateContentMedias (descriptor) {
+    Logger.debug(LOG_PREFIX, `Composed adapter negotiation for content medias requested at session ${this.id}`, { descriptor } );
     const { contentAdapter } = this._adapters;
-    const contentDescription = this.remoteDescriptor? this.remoteDescriptor.contentVideoSdp : null;
     const isAnswerer = this.negotiationRole === C.NEGOTIATION_ROLE.ANSWERER;
     const contentOptions = isAnswerer ?
       this._options :
       { ...this._options, mediaProfile: C.MEDIA_PROFILE.CONTENT };
-    if (this.profiles.content || contentDescription) {
+    if (this.profiles.content || descriptor) {
       try {
         const contentMedias = await contentAdapter.negotiate(
-          this.roomId, this.userId, this.id, contentDescription,
+          this.roomId, this.userId, this.id, descriptor,
           this.type, contentOptions
         );
         contentMedias.forEach(m => {
@@ -185,31 +182,43 @@ module.exports = class SDPSession extends MediaSession {
     }
   }
 
+  async _negotiateApplicationMedias (descriptor) {
+    return this._rejectMedia(descriptor);
+  };
+
+  // TODO this is a stub
+  async _rejectMedia (descriptor) {
+    return [];
+  };
+
   async _composedAdapterProcess () {
-    let audioMedias = [];
-    let videoMedias = [];
-    let contentMedias = [];
+    const annotatedPartialDescriptors = SdpWrapper.getAnnotatedPartialDescriptors(this.remoteDescriptor._plainSdp);
+    const processMethods = {
+      [C.MEDIA_PROFILE.AUDIO]: this._negotiateAudioMedias.bind(this),
+      [C.MEDIA_PROFILE.MAIN]: this._negotiateVideoMedias.bind(this),
+      [C.MEDIA_PROFILE.CONTENT]: this._negotiateContentMedias.bind(this),
+      [C.MEDIA_PROFILE.APPLICATION]: this._negotiateApplicationMedias.bind(this),
+      [C.MEDIA_PROFILE.UNSUPPORTED]: this._rejectMedia.bind(this),
+    };
 
-    try {
-      audioMedias = await this._negotiateAudioMedias();
-    } catch (error) {
-      Logger.error(LOG_PREFIX, `Failed to negotiate audio medias, none will be generated due to ${error.message}`,
-        { error: this._handleError(error) });
-    }
-    try {
-      videoMedias = await this._negotiateVideoMedias();
-    } catch (error) {
-      Logger.error(LOG_PREFIX, `Failed to negotiate video medias, none will be generated due to ${error.message}`,
-        { error: this._handleError(error) });
-    }
-    try {
-      contentMedias = await this._negotiateContentMedias();
-    } catch (error) {
-      Logger.error(LOG_PREFIX, `Failed to negotiate content medias, none will be generated due to ${error.message}`,
-        { error: this._handleError(error) });
-    }
-
-    return this.medias.concat(audioMedias, videoMedias, contentMedias);
+    return Object.keys(annotatedPartialDescriptors).reduce((promise, type) => {
+      return promise.then(() => {
+        const { descriptor, indexes } = annotatedPartialDescriptors[type];
+        return processMethods[type](descriptor)
+          .then(processedMedias => {
+            processedMedias.forEach((mediaUnit, adapterIndex) => {
+              const sdpPosition = indexes[adapterIndex]
+              this.medias[sdpPosition] = mediaUnit;
+            })
+          })
+          .catch(error => {
+            Logger.error(LOG_PREFIX, `Failed to negotiate ${type} medias, none will be generated due to ${error.message}`,
+              { error: this._handleError(error) });
+        });
+      });
+    }, Promise.resolve()).then(() => {
+      Logger.info(LOG_PREFIX, `Composed adapter processing finished for ${this.id}`);
+    });
   }
 
   _monoAdapterProcess () {
@@ -336,7 +345,7 @@ module.exports = class SDPSession extends MediaSession {
     }
 
     try {
-      this.medias = await processMethod();
+      await processMethod();
     } catch (error) {
       Logger.error(LOG_PREFIX, `Failed to process SDP session ${this.id} due to ${error.message}`,
         { roomId: this.roomId, userId: this.userId, mediaSessionId: this.id, error });

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -118,8 +118,8 @@ module.exports = class SDPSession extends MediaSession {
           descriptor, this.type, audioOptions
         );
         audioMedias.forEach(m => {
-          m.localDescriptor = SdpWrapper.getAudioSDP(m.localDescriptor._plainSdp)
-          Logger.debug(LOG_PREFIX, `Composed adapter negotiation succeeded for audio media unit ${m.id}`, m.localDescriptor._plainSdp)
+          m.localDescriptor = m.localDescriptor.audioSdp;
+          Logger.debug(LOG_PREFIX, `Composed adapter negotiation succeeded for audio media unit ${m.id}`, m.localDescriptor._plainSdp);
         });
         return audioMedias;
       } catch (e) {
@@ -145,8 +145,8 @@ module.exports = class SDPSession extends MediaSession {
           descriptor, this.type, videoOptions
         );
         videoMedias.forEach(m => {
-          m.localDescriptor =  SdpWrapper.getVideoSDP(m.localDescriptor._plainSdp);
-          Logger.debug(LOG_PREFIX, `Composed adapter negotiation succeeded for video media unit ${m.id}`, m.localDescriptor._plainSdp)
+          m.localDescriptor =  m.localDescriptor.mainVideoSdp;
+          Logger.debug(LOG_PREFIX, `Composed adapter negotiation succeeded for video media unit ${m.id}`, m.localDescriptor._plainSdp);
         });
         return videoMedias;
       } catch (e) {
@@ -164,6 +164,7 @@ module.exports = class SDPSession extends MediaSession {
     const contentOptions = isAnswerer ?
       this._options :
       { ...this._options, mediaProfile: C.MEDIA_PROFILE.CONTENT };
+
     if (this.profiles.content || !!descriptor) {
       try {
         const contentMedias = await contentAdapter.negotiate(
@@ -171,8 +172,8 @@ module.exports = class SDPSession extends MediaSession {
           this.type, contentOptions
         );
         contentMedias.forEach(m => {
-          m.localDescriptor = SdpWrapper.getContentSDP(m.localDescriptor._plainSdp);
-          Logger.debug(LOG_PREFIX, `Composed adapter negotiation succeeded for content media unit ${m.id}`, m.localDescriptor._plainSdp)
+          m.localDescriptor = m.localDescriptor.contentVideoSdp;
+          Logger.debug(LOG_PREFIX, `Composed adapter negotiation succeeded for content media unit ${m.id}`, m.localDescriptor._plainSdp);
         });
         return contentMedias;
       } catch (e) {
@@ -293,7 +294,10 @@ module.exports = class SDPSession extends MediaSession {
         // we don't support full, unlimited renegotiation as of now due to media
         // server limitations. I understand this is kinda coupling the session
         // logic to a limitation of Kurento and this should be handled there.
-        // I'll do it once I have time - prlanzarin 25/04/2018 FIXME
+        // Also, this method works well, but it needs a refactor to be similar
+        // to composedAdapterNegotiation (or even re-use it). Needs a media server
+        // adapter data interfacing review, though.
+        // I'll do it once I have time - prlanzarin 31/10/2019 FIXME
         if (this.remoteDescriptor.mainVideoSdp && this.shouldProcessRemoteDescriptorAsAnswerer) {
           try {
             const videoMedia = this.medias.find(m => m.mediaTypes.video);
@@ -319,6 +323,17 @@ module.exports = class SDPSession extends MediaSession {
           }
         }
 
+        if (this.remoteDescriptor.invalidSdps
+          && (!this.localDescriptor || !this.localDescriptor.invalidSdps)) {
+          const rejectedMedias = await this._rejectMedias(this.remoteDescriptor.invalidSdps);
+          let currentMediaLength = this.medias.length + this.invalidMedias.length;
+          rejectedMedias.forEach(rm => {
+            rm.sdpPosition = currentMediaLength;
+            currentMediaLength +=1;
+          });
+          this.invalidMedias = this.invalidMedias.concat(rejectedMedias);
+        }
+
         if (this.remoteDescriptor.contentVideoSdp) {
           // This is an ANSWERER descriptor to us (as OFFERERS)
           if (this.shouldProcessRemoteDescriptorAsAnswerer || (this.localDescriptor && this.localDescriptor.contentVideoSdp)) {
@@ -330,10 +345,10 @@ module.exports = class SDPSession extends MediaSession {
             // This is a renegotiation for a new content media for us as ANSWERERS
             Logger.info(LOG_PREFIX, "Renegotiating content streams for", this.id, this.remoteDescriptor.contentVideoSdp);
             try {
-              const contentMedias = await this._negotiateContentMedias();
+              const contentMedias = await this._negotiateContentMedias(this.remoteDescriptor.contentVideoSdp);
               let currentMediaLength = this.medias.length + this.invalidMedias.length;
               contentMedias.forEach(cm => {
-                cm.sdpPosition = currentMediaLength
+                cm.sdpPosition = currentMediaLength;
                 currentMediaLength +=1;
               });
               this.medias = this.medias.concat(contentMedias);
@@ -348,7 +363,7 @@ module.exports = class SDPSession extends MediaSession {
               const contentMedias = await this._negotiateContentMedias();
               let currentMediaLength = this.medias.length + this.invalidMedias.length;
               contentMedias.forEach(cm => {
-                cm.sdpPosition = currentMediaLength
+                cm.sdpPosition = currentMediaLength;
                 currentMediaLength +=1;
               });
               this.medias = this.medias.concat(contentMedias);
@@ -415,7 +430,12 @@ module.exports = class SDPSession extends MediaSession {
       throw (this._handleError(error));
     }
 
-    this.localDescriptor = this.getAnswer();
+    try {
+      this.localDescriptor = this.getAnswer();
+    } catch (error) {
+      throw error;
+    }
+
     localDescriptorAnswer = this._hasCompleteLocalDescriptor()
       ? this.localDescriptor._plainSdp
       : null;
@@ -466,6 +486,13 @@ module.exports = class SDPSession extends MediaSession {
   getAnswer () {
     let header = '', body = '';
     let mediasToProcess = [];
+    const nofMedias = this.medias.length + this.invalidMedias.length;
+    // Short exit: we have a single media. Probably a proper single m=* line
+    // session or a multi m=* line where the adapter does it stuff right
+    if (nofMedias === 1) {
+      const media = this.medias[0] || this.invalidMedias[0];
+      return media.localDescriptor._plainSdp;
+    }
     this.medias.forEach((m) => {
       mediasToProcess[m.sdpPosition] = m;
     });
@@ -475,8 +502,12 @@ module.exports = class SDPSession extends MediaSession {
     mediasToProcess = mediasToProcess.filter(m => m);
     const validMedia = mediasToProcess.find(m => m.type !== C.MEDIA_TYPE.INTERNAL_UNSUPPORTED);
 
-    // TODO review this early exit
-    if (!validMedia) return;
+    // TODO we should have a fallback SDP header for this case instead
+    // of churning a NO_AVAILABLE_CODEC error
+    if (!validMedia) {
+      Logger.warn(LOG_PREFIX, `No supported media found for ${this.id}, rejecting it with MEDIA_NO_AVAILABLE_CODEC`);
+      throw (this._handleError(C.ERROR.MEDIA_NO_AVAILABLE_CODEC));
+    }
 
     header = validMedia.localDescriptor.sessionDescriptionHeader;
     mediasToProcess.forEach(m => {

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -159,7 +159,7 @@ module.exports = class User {
 
       return ({ session, answer });
     } catch (error) {
-      Logger.error(LOG_PREFIX, `Subscribe from user ${this.id} failed`,
+      Logger.error(LOG_PREFIX, `Subscribe from user ${this.id} failed due to ${error.message}`,
         { userId: this.id, roomId: this.roomId, error });
       throw (this._handleError(error));
     }
@@ -171,7 +171,7 @@ module.exports = class User {
       const answer = await this._startSession(session.id);
       return ({ session, answer });
     } catch (error) {
-      Logger.error(LOG_PREFIX, `Publish from user ${this.id} failed`,
+      Logger.error(LOG_PREFIX, `Publish from user ${this.id} failed due to ${error.message}`,
         { error });
       throw (this._handleError(error));
     }
@@ -192,7 +192,7 @@ module.exports = class User {
       const answer = await this._startSession(recordingSession.id);
       return ({ recordingSession, answer });
     } catch (error) {
-      Logger.error(LOG_PREFIX, `startRecording from user ${this.id} of rec ${source.id} failed`,
+      Logger.error(LOG_PREFIX, `startRecording from user ${this.id} of rec ${source.id} failed due to ${error.message}`,
         { userId: this.id, roomId: this.roomId, error });
       throw (this._handleError(error));
     }

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -218,25 +218,17 @@ module.exports = class SdpWrapper {
     return params;
   }
 
-  static hasContentSlides (mediaLine) {
-    return mediaLine.invalid
-      ? mediaLine.invalid.some(({ value }) => { return value.includes('slides') })
-      : false;
-  }
-
   static isAudio (mediaLine) {
     return mediaLine.type == "audio";
   }
 
   static isVideo (mediaLine) {
-    return mediaLine.type === "video" && !SdpWrapper.hasContentSlides(mediaLine);
+    return mediaLine.type === "video" && !SdpWrapper.isContentSlides(mediaLine);
   }
 
-  static isContent (mediaLine) {
-    const hasContentSlides = mediaLine.invalid
-      ? mediaLine.invalid.some(({ value }) => { return value.includes('slides') })
-      : false;
-    return mediaLine.type === "video" && SdpWrapper.hasContentSlides(mediaLine);
+  static isContentSlides (mediaLine) {
+    const hasContentSlides = !!mediaLine.content && mediaLine.content === 'slides';
+    return mediaLine.type === "video" && hasContentSlides;
   }
 
   static isApplication (mediaLine) {
@@ -248,8 +240,8 @@ module.exports = class SdpWrapper {
       return C.MEDIA_PROFILE.AUDIO;
     } else if (SdpWrapper.isVideo(mediaLine)) {
       return C.MEDIA_PROFILE.MAIN;
-    } else if (SdpWrapper.isContent(mediaLine)) {
-      return C.MEDIA_PROFILE.isContent;
+    } else if (SdpWrapper.isContentSlides(mediaLine)) {
+      return C.MEDIA_PROFILE.CONTENT;
     } else if (SdpWrapper.isApplication(mediaLine)) {
       return C.MEDIA_PROFILE.APPLICATION;
     } else {
@@ -264,7 +256,7 @@ module.exports = class SdpWrapper {
    */
   static getContentDescription (sdp) {
     var res = transform.parse(sdp);
-    res.media = res.media.filter(SdpWrapper.isContent);
+    res.media = res.media.filter(SdpWrapper.isContentSlides);
     // No content:slides media in this one
     if (res.media.length <= 0) {
       return;
@@ -526,9 +518,7 @@ module.exports = class SdpWrapper {
           codecToFilter = contentCodec;
           actualMediaProfile = this.mediaProfile;
         } else {
-          const hasContentSlides = ml.invalid
-            ? ml.invalid.some(({ value }) => { return value.includes('slides') })
-            : false;
+          const hasContentSlides = SdpWrapper.isContentSlides(ml);
           codecToFilter = hasContentSlides? contentCodec : videoCodec;
           actualMediaProfile = hasContentSlides? C.MEDIA_PROFILE.CONTENT : C.MEDIA_PROFILE.MAIN
         }
@@ -643,9 +633,7 @@ module.exports = class SdpWrapper {
       } else if (mediaProfile === C.MEDIA_PROFILE.CONTENT) {
         codecToFilter = contentCodec;
       } else {
-        const hasContentSlides = ml.invalid
-          ? ml.invalid.some(({ value }) => { return value.includes('slides') })
-          : false;
+        const hasContentSlides = SdpWrapper.isContentSlides(ml);
         codecToFilter = hasContentSlides? contentCodec : videoCodec;
       }
 
@@ -708,9 +696,7 @@ module.exports = class SdpWrapper {
 
     res.media.forEach(ml => {
       if (ml.type == 'video') {
-        const hasContentSlides = ml.invalid
-          ? ml.invalid.some(({ value }) => { return value.includes('slides') })
-          : false;
+        const hasContentSlides = SdpWrapper.isContentSlides(ml);
         if (updatedWrapper.mediaProfile === C.MEDIA_PROFILE.MAIN || !hasContentSlides) {
           if (!codecMap.codec_video_main) {
             ml.rtp.some(rtp => {

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -340,6 +340,26 @@ module.exports = class SdpWrapper {
     }
   }
 
+  static getInvalidDescriptions (sdp) {
+    var res = transform.parse(sdp);
+    const predicate = mediaLine => {
+      const mediaLineType = SdpWrapper.getMediaLineType(mediaLine);
+      return mediaLineType === C.MEDIA_PROFILE.APPLICATION || mediaLineType === C.MEDIA_PROFILE.UNSUPPORTED;
+    };
+    res.media = res.media.filter(predicate);
+    // No medias in this one
+    if (res.media.length <= 0) {
+      return;
+    }
+
+    const mangledSdp = transform.write(res);
+    if(typeof mangledSdp != undefined && mangledSdp && mangledSdp != "") {
+      return mangledSdp;
+    }
+    else
+      return sdp;
+  }
+
   /**
    * Given a sdp-transform parsed SDP jsonSDP and an Array of JSON media lines mediaLines,
    * returns a new SDP composed of jsonSDP's header and mediaLines
@@ -634,6 +654,7 @@ module.exports = class SdpWrapper {
     this.audioSdp =  SdpWrapper.getAudioDescription(description);
     this.mainVideoSdp = SdpWrapper.getMainDescription(description);
     this.contentVideoSdp = SdpWrapper.getContentDescription(description);
+    this.invalidSdps = SdpWrapper.getInvalidDescriptions(description);
     this._mediaCapabilities.hasContent = this.contentVideoSdp? true : false;
   }
 

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -235,6 +235,27 @@ module.exports = class SdpWrapper {
     return mediaLine.type == "application";
   }
 
+  static annotatedDescriptorEntry () {
+    return {
+      mediaLines: [],
+      indexes: [],
+      descriptor: '',
+    };
+  }
+
+  static annotatedDescriptorsDictionary () {
+    return {
+      numberOfMediaLines: 0,
+      annotatedDescriptors: {
+        [C.MEDIA_PROFILE.AUDIO]: SdpWrapper.annotatedDescriptorEntry(),
+        [C.MEDIA_PROFILE.MAIN]:  SdpWrapper.annotatedDescriptorEntry(),
+        [C.MEDIA_PROFILE.CONTENT]: SdpWrapper.annotatedDescriptorEntry(),
+        [C.MEDIA_PROFILE.APPLICATION]: SdpWrapper.annotatedDescriptorEntry(),
+        [C.MEDIA_PROFILE.UNSUPPORTED]: SdpWrapper.annotatedDescriptorEntry(),
+      }
+    };
+  }
+
   static getMediaLineType (mediaLine) {
     if (SdpWrapper.isAudio(mediaLine)) {
       return C.MEDIA_PROFILE.AUDIO;
@@ -327,7 +348,7 @@ module.exports = class SdpWrapper {
    * @return {String} A SDP composed of jsonSDP's header and mediaLines
    */
   static reassembleSDPFromMediaLines (jsonSDP, mediaLines) {
-    if (!mediaLines) return '';
+    if (!mediaLines || mediaLines.length <= 0) return '';
     let partialSDP = Object.assign({}, jsonSDP);
     partialSDP.media = mediaLines;
     const stringifiedPartialSDP = transform.write(partialSDP) || '';
@@ -341,8 +362,8 @@ module.exports = class SdpWrapper {
    * @return {Array.String} Array of partial descriptors
    */
   static getPartialDescriptions (descriptor) {
-    if (descriptor == null) {
-      return [];
+    if (!descriptor) {
+      return [descriptor];
     }
 
     let res = transform.parse(descriptor);
@@ -357,13 +378,12 @@ module.exports = class SdpWrapper {
   }
 
   /**
-   * Given a SDP, return an Object of the following format:
+   * Given a SDP, return an annotatedDescriptorsDictionary of the following format
    * {
-   *   entry1,
-   *   ...,
-   *   entryN
+   *   numberOfMediaLines: Intenger
+   *   annotatedDescriptors: Array<annotatedDescriptorEntry>
    * }
-   * Where entry is an Object of the following format:
+   * Where annotatedDescriptorEntry is an Object of the following format:
    *   <type: String>: {
    *     mediaLines: Array<Objects> An array of JSON media lines of type <type>
    *     descriptor: String The aggregated SDP generated from mediaLines
@@ -376,31 +396,26 @@ module.exports = class SdpWrapper {
    * with their types annotated and original SDP ordering preserver
    */
   static getAnnotatedPartialDescriptors (sdp = '') {
+    const annotatedDescriptorsDictionary = SdpWrapper.annotatedDescriptorsDictionary();
     if (!sdp) {
-      return {};
+      return annotatedDescriptorsDictionary;
     }
-
     let jsonSDP = transform.parse(sdp);
-    let annotatedDescriptorsList = {}
+    const { annotatedDescriptors } = annotatedDescriptorsDictionary;
+    annotatedDescriptorsDictionary.numberOfMediaLines = jsonSDP.media.length || 0;
     jsonSDP.media.forEach((mediaLine, index) => {
       const type = SdpWrapper.getMediaLineType(mediaLine);
-      if (!annotatedDescriptorsList[type]) {
-        annotatedDescriptorsList[type] = {
-          mediaLines: [],
-          indexes: [],
-        };
-      }
-      const entry = annotatedDescriptorsList[type];
+      const entry = annotatedDescriptors[type];
       entry.mediaLines.push(mediaLine);
       entry.indexes.push(index);
     });
 
-    Object.keys(annotatedDescriptorsList).forEach(type => {
-      const entry = annotatedDescriptorsList[type];
+    Object.keys(annotatedDescriptors).forEach(type => {
+      const entry = annotatedDescriptors[type];
       entry.descriptor = SdpWrapper.reassembleSDPFromMediaLines(jsonSDP, entry.mediaLines);
     });
 
-    return annotatedDescriptorsList || {};
+    return annotatedDescriptorsDictionary || {};
   }
 
   /**

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -628,7 +628,6 @@ module.exports = class SdpWrapper {
     this.sessionDescriptionHeader = SdpWrapper.getSessionDescription(description);
     this.audioSdp =  SdpWrapper.getAudioDescription(description);
     this.mainVideoSdp = SdpWrapper.getMainDescription(description);
-    this.partialDescriptors = SdpWrapper.getPartialDescriptions(description);
     this.contentVideoSdp = SdpWrapper.getContentDescription(description);
     this._mediaCapabilities.hasContent = this.contentVideoSdp? true : false;
   }

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -10,7 +10,7 @@ const transform = require('sdp-transform');
 const C = require('../constants/constants.js');
 
 module.exports = class SdpWrapper {
-  constructor(sdp, mediaSpecs, type) {
+  constructor(sdp, mediaSpecs, type, params = {}) {
     this._plainSdp = sdp;
     this._jsonSdp = transform.parse(sdp);
     this._mediaLines = {};
@@ -18,8 +18,11 @@ module.exports = class SdpWrapper {
     this._profileThreshold = "ffffff";
     this.mediaSpecs = mediaSpecs;
     this.mediaProfile = type;
-    this.supportedCodecs = SdpWrapper.getSupportedCodecsFromSpec(mediaSpecs);
-    this.processSdp();
+    this.preProcess = params.preProcess || true;
+    if (this.preProcess) {
+      this.supportedCodecs = SdpWrapper.getSupportedCodecsFromSpec(mediaSpecs);
+      this.processSdp();
+    }
   }
 
   get plainSdp() {
@@ -34,13 +37,12 @@ module.exports = class SdpWrapper {
     return this._plainSdp.replace(/(a=fmtp:).*/g, '');
   }
 
-  static nonPureReplaceServerIpv4(sdp, ipv4) {
-    return sdp.replace(/(IP4\s[0-9.]*)/g, 'IP4 ' + ipv4);
-
-  }
-
   replaceServerIpv4 (ipv4) {
     return this._plainSdp.replace(/(IP4\s[0-9.]*)/g, 'IP4 ' + ipv4);
+  }
+
+  static convertToString (jsonSdp) {
+    return transform.write(jsonSdp);
   }
 
   static nonPureReplaceServerIpv4 (sdp, ipv4) {
@@ -68,6 +70,15 @@ module.exports = class SdpWrapper {
         && entry !== 'codec_video_main'
         && entry !== 'codec_audio';
     });
+  }
+
+  generateInactiveDescriptor () {
+    const newSDP = { ...this._jsonSdp };
+    newSDP.media.forEach(ml => {
+      ml.port = 0;
+      ml.direction = 'inactive';
+    });
+    return transform.write(newSDP);
   }
 
   hasAudio () {
@@ -181,7 +192,7 @@ module.exports = class SdpWrapper {
    * @return {String} a SDP stripped of its header (m=* lines only)
    */
   static removeSessionDescription (sdp) {
-    const sd = sdp.match(/(?=[\s\S]+?)(m=audio[\s\S]+|m=video[\s\S]+)/i);
+    const sd = sdp.match(/(?=[\s\S]+?)(m=audio[\s\S]+|m=video[\s\S]+|m=application[\s\S]+)/i);
     return sd? sd[1] : undefined;
   }
 
@@ -324,6 +335,7 @@ module.exports = class SdpWrapper {
    * @return {String} A SDP composed of jsonSDP's header and mediaLines
    */
   static reassembleSDPFromMediaLines (jsonSDP, mediaLines) {
+    if (!mediaLines) return '';
     let partialSDP = Object.assign({}, jsonSDP);
     partialSDP.media = mediaLines;
     const stringifiedPartialSDP = transform.write(partialSDP) || '';
@@ -606,11 +618,9 @@ module.exports = class SdpWrapper {
   }
 
   processSdp () {
-    let description = this._plainSdp = this.submitToSpec(this._plainSdp, this.mediaSpecs, this.mediaProfile)
+    let description = this._plainSdp = this.submitToSpec(this._plainSdp, this.mediaSpecs, this.mediaProfile);
     this._jsonSdp = transform.parse(this._plainSdp);
-
     description = description.toString().replace(/telephone-event/, "TELEPHONE-EVENT");
-
     this._mediaCapabilities.hasVideo = this._hasVideo();
     this._mediaCapabilities.hasAudio = this._hasAudio();
     this._mediaCapabilities.hasAvailableVideoCodec = this._hasAvailableVideoCodec();
@@ -621,8 +631,6 @@ module.exports = class SdpWrapper {
     this.partialDescriptors = SdpWrapper.getPartialDescriptions(description);
     this.contentVideoSdp = SdpWrapper.getContentDescription(description);
     this._mediaCapabilities.hasContent = this.contentVideoSdp? true : false;
-
-    return;
   }
 
   static filterByVideoCodec (sdp, videoCodec, contentCodec, mediaProfile) {
@@ -742,9 +750,5 @@ module.exports = class SdpWrapper {
     updatedWrapper.mediaSpecs.codec_video_content = codec_video_content? codec_video_content: updatedWrapper.mediaSpecs.codec_video_content;
     updatedWrapper.mediaSpecs.codec_audio = codec_audio? codec_audio : updatedWrapper.mediaSpecs.codec_audio;
     return updatedWrapper.mediaSpecs;
-  }
-
-  static convertToString (jsonSdp) {
-    return transform.write(jsonSdp);
   }
 };

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -18,6 +18,7 @@ module.exports = class SdpWrapper {
     this._profileThreshold = "ffffff";
     this.mediaSpecs = mediaSpecs;
     this.mediaProfile = type;
+    this.supportedCodecs = SdpWrapper.getSupportedCodecsFromSpec(mediaSpecs);
     this.processSdp();
   }
 
@@ -59,6 +60,14 @@ module.exports = class SdpWrapper {
   static getContentSDP (sdp) {
     const csdp =  SdpWrapper.getContentDescription(sdp);
     return csdp;
+  }
+
+  static getSupportedCodecsFromSpec (spec) {
+    return Object.keys(spec).filter(entry => {
+      return entry !== 'codec_video_content'
+        && entry !== 'codec_video_main'
+        && entry !== 'codec_audio';
+    });
   }
 
   hasAudio () {
@@ -198,6 +207,45 @@ module.exports = class SdpWrapper {
     return params;
   }
 
+  static hasContentSlides (mediaLine) {
+    return mediaLine.invalid
+      ? mediaLine.invalid.some(({ value }) => { return value.includes('slides') })
+      : false;
+  }
+
+  static isAudio (mediaLine) {
+    return mediaLine.type == "audio";
+  }
+
+  static isVideo (mediaLine) {
+    return mediaLine.type === "video" && !SdpWrapper.hasContentSlides(mediaLine);
+  }
+
+  static isContent (mediaLine) {
+    const hasContentSlides = mediaLine.invalid
+      ? mediaLine.invalid.some(({ value }) => { return value.includes('slides') })
+      : false;
+    return mediaLine.type === "video" && SdpWrapper.hasContentSlides(mediaLine);
+  }
+
+  static isApplication (mediaLine) {
+    return mediaLine.type == "application";
+  }
+
+  static getMediaLineType (mediaLine) {
+    if (SdpWrapper.isAudio(mediaLine)) {
+      return C.MEDIA_PROFILE.AUDIO;
+    } else if (SdpWrapper.isVideo(mediaLine)) {
+      return C.MEDIA_PROFILE.MAIN;
+    } else if (SdpWrapper.isContent(mediaLine)) {
+      return C.MEDIA_PROFILE.isContent;
+    } else if (SdpWrapper.isApplication(mediaLine)) {
+      return C.MEDIA_PROFILE.APPLICATION;
+    } else {
+      return C.MEDIA_PROFILE.UNSUPPORTED;
+    }
+  }
+
   /**
    * Given a SDP, return its Content Description
    * @param  {string} sdp The Session Descriptor
@@ -205,13 +253,7 @@ module.exports = class SdpWrapper {
    */
   static getContentDescription (sdp) {
     var res = transform.parse(sdp);
-    res.media = res.media.filter((ml) => {
-      const hasContentSlides = ml.invalid
-        ? ml.invalid.some(({ value }) => { return value.includes('slides') })
-        : false;
-      return ml.type === "video" && hasContentSlides;
-    });
-
+    res.media = res.media.filter(SdpWrapper.isContent);
     // No content:slides media in this one
     if (res.media.length <= 0) {
       return;
@@ -232,7 +274,7 @@ module.exports = class SdpWrapper {
    */
   static getAudioDescription (sdp) {
     var res = transform.parse(sdp);
-    res.media = res.media.filter(function (ml) { return ml.type == "audio" });
+    res.media = res.media.filter(SdpWrapper.isAudio);
 
     // Everything has been filtered and no audio was found
     if (res.media.length <= 0) {
@@ -258,12 +300,7 @@ module.exports = class SdpWrapper {
    */
   static getMainDescription (description) {
     const res = transform.parse(description);
-    res.media = res.media.filter(ml => {
-      const hasContentSlides = ml.invalid
-        ? ml.invalid.some(({ value }) => { return value.includes('slides') })
-        : false;
-      return ml.type === "video" && !hasContentSlides;
-    });
+    res.media = res.media.filter(SdpWrapper.isVideo);
 
     // Everything has been filtered and no video/main was found
     if (res.media.length <= 0) {
@@ -280,27 +317,86 @@ module.exports = class SdpWrapper {
   }
 
   /**
-   * Given a SDP, return all video descriptors
+   * Given a sdp-transform parsed SDP jsonSDP and an Array of JSON media lines mediaLines,
+   * returns a new SDP composed of jsonSDP's header and mediaLines
+   * @param  {Object} jsonSDP A sdp-transform parsed JSON SDP
+   * @params {Array} mediaLines An array of sdp-transform parsed JSON media lines
+   * @return {String} A SDP composed of jsonSDP's header and mediaLines
+   */
+  static reassembleSDPFromMediaLines (jsonSDP, mediaLines) {
+    let partialSDP = Object.assign({}, jsonSDP);
+    partialSDP.media = mediaLines;
+    const stringifiedPartialSDP = transform.write(partialSDP) || '';
+    return stringifiedPartialSDP;
+  };
+
+  /**
+   * Given a SDP, return all partial descriptors of either m=video or m=audio variety.
+   * A partial descriptor is a single m=* line descriptor with a shared SDP header.
    * @param  {string} sdp The Session Descriptor
-   * @return {Array.String} Video content descriptors
+   * @return {Array.String} Array of partial descriptors
    */
   static getPartialDescriptions (descriptor) {
     if (descriptor == null) {
-      return [descriptor];
+      return [];
     }
 
     let res = transform.parse(descriptor);
     let descriptorsList = []
-    res.media = res.media.filter((ml) => { return ml.type == "video" || ml.type === 'audio'}); //&& ml.invalid[0].value != 'content:slides'});
     res.media.forEach(media => {
-      let partialSDP = Object.assign({}, res);
-      partialSDP.media = [media];
-      const stringifiedPartialSDP = transform.write(partialSDP);
+      const stringifiedPartialSDP = SdpWrapper.reassembleSDPFromMediaLines(res, [media]);
       if (stringifiedPartialSDP && stringifiedPartialSDP !== '') {
-        descriptorsList .push(stringifiedPartialSDP);
+        descriptorsList.push(stringifiedPartialSDP);
       }
     });
     return descriptorsList;
+  }
+
+  /**
+   * Given a SDP, return an Object of the following format:
+   * {
+   *   entry1,
+   *   ...,
+   *   entryN
+   * }
+   * Where entry is an Object of the following format:
+   *   <type: String>: {
+   *     mediaLines: Array<Objects> An array of JSON media lines of type <type>
+   *     descriptor: String The aggregated SDP generated from mediaLines
+   *     indexes: Array<Integer> The indexes in the original SDP for each of the media lines
+   *   }
+   *
+   * The dictionary keys <type> are Strings defined in C.MEDIA_PROFILE
+   * @param  {string} sdp The SDP
+   * @return {Object} An Object aggregating all partial SDPs aggregated by type,
+   * with their types annotated and original SDP ordering preserver
+   */
+  static getAnnotatedPartialDescriptors (sdp = '') {
+    if (!sdp) {
+      return {};
+    }
+
+    let jsonSDP = transform.parse(sdp);
+    let annotatedDescriptorsList = {}
+    jsonSDP.media.forEach((mediaLine, index) => {
+      const type = SdpWrapper.getMediaLineType(mediaLine);
+      if (!annotatedDescriptorsList[type]) {
+        annotatedDescriptorsList[type] = {
+          mediaLines: [],
+          indexes: [],
+        };
+      }
+      const entry = annotatedDescriptorsList[type];
+      entry.mediaLines.push(mediaLine);
+      entry.indexes.push(index);
+    });
+
+    Object.keys(annotatedDescriptorsList).forEach(type => {
+      const entry = annotatedDescriptorsList[type];
+      entry.descriptor = SdpWrapper.reassembleSDPFromMediaLines(jsonSDP, entry.mediaLines);
+    });
+
+    return annotatedDescriptorsList || {};
   }
 
   /**
@@ -528,39 +624,6 @@ module.exports = class SdpWrapper {
 
     return;
   }
-
-  /* DEVELOPMENT METHODS */
-  _disableMedia  (sdp) {
-    return sdp.replace(/(m=application\s)\d*/g, "$10");
-  };
-
-  /**
-   * Given a SDP, add Floor Control response
-   * @param  {string} sdp The Session Descriptor
-   * @return {string}     A new Session Descriptor with Floor Control
-   */
-  _addFloorControl (sdp) {
-    return sdp.replace(/a=inactive/i, 'a=sendrecv\r\na=floorctrl:c-only\r\na=setup:active\r\na=connection:new');
-  }
-
-  /**
-   * Given a SDP, add Floor Control response to reinvite
-   * @param  {string} sdp The Session Descriptor
-   * @return {string}     A new Session Descriptor with Floor Control Id
-   */
-  _addFloorId (sdp) {
-    sdp = sdp.replace(/(a=floorctrl:c-only)/i, '$1\r\na=floorid:1 m-stream:3');
-    return sdp.replace(/(m=video.*)([\s\S]*?m=video.*)([\s\S]*)/i, '$1\r\na=content:main\r\na=label:1$2\r\na=content:slides\r\na=label:3$3');
-  }
-
-  /**
-   * Given the string representation of a Session Descriptor, remove it's video
-   * @param  {string} sdp The Session Descriptor
-   * @return {string}     A new Session Descriptor without the video
-   */
-  _removeVideoSdp  (sdp) {
-    return sdp.replace(/(m=video[\s\S]+)/g,'');
-  };
 
   static filterByVideoCodec (sdp, videoCodec, contentCodec, mediaProfile) {
     let res = typeof sdp === 'string'? transform.parse(sdp) : sdp;

--- a/package-lock.json
+++ b/package-lock.json
@@ -882,7 +882,7 @@
         "minimist": "^1.2.0",
         "promise": "7.1.1",
         "promisecallback": "0.0.4",
-        "reconnect-ws": "github:KurentoForks/reconnect-ws#f287385d75861654528c352e60221f95c9209f8a"
+        "reconnect-ws": "github:KurentoForks/reconnect-ws#master"
       }
     },
     "kurento-client-core": {
@@ -1217,7 +1217,7 @@
       "version": "github:KurentoForks/reconnect-ws#f287385d75861654528c352e60221f95c9209f8a",
       "from": "github:KurentoForks/reconnect-ws#master",
       "requires": {
-        "reconnect-core": "github:KurentoForks/reconnect-core#921d43e91578abb2fb2613f585c010c1939cf734",
+        "reconnect-core": "github:KurentoForks/reconnect-core",
         "websocket-stream": "~0.5.1"
       }
     },
@@ -1323,9 +1323,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "sdp-transform": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.4.1.tgz",
-      "integrity": "sha512-dCReSJ6NtCW6goKkKBEHcIknBS1pKejnMw+S3p3jl0PALPFrbjbreCyQ+CABtFxl2GXD2/05+C2q2gZP23dUWQ=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.13.0.tgz",
+      "integrity": "sha512-3zT7pcjR090E0WCV9eOtFX06iojoNKsyMXqXs7clOs8sy+RoegR0cebmCuCrTKdY2jw1XhT9jkraygJrqAUwzA=="
     },
     "sha1": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
     "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.8",
     "modesl": "1.2.0",
     "node-docker-api": "1.1.22",
+    "pegjs": "0.8.0",
     "readable-id": "1.0.0",
     "redis": "2.8.0",
-    "sdp-transform": "2.4.1",
+    "sdp-transform": "2.13.0",
     "sip.js": "git+https://github.com/mconf/sip.js.git#v0.7.5.4",
     "winston": "2.4.2",
     "winston-daily-rotate-file": "1.7.2",
-    "ws": "3.3.3",
-    "pegjs": "0.8.0"
+    "ws": "3.3.3"
   },
   "optionalDependencies": {}
 }


### PR DESCRIPTION
Closes #139.
Also:
  - Bump `sdp-transform` to 2.13.0
  - Improve some errors logs in mcs-core#`User`
  - [freeswitch] Encode URI before setting it in the UA 
  - Workaround: also emit `MEDIA_DISCONNECTED` for the media session when a child media unit gets disconnected.