### PR TITLE
Closes #151

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -52,3 +52,5 @@ screenshareSubscriberSpecSlave: SCREENSHARE_SUBSCRIBER_SLAVE
 kurentoAllowedCandidateIps:
   __name: KURENTO_ALLOWED_CANDIDATE_IPS
   __format: json
+
+addTimestampToAkkaMessages: AKKA_MSG_TIMESTAMP

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -186,3 +186,5 @@ mediaThresholds:
   global: 0
   perRoom: 0
   perUser: 0
+# Whether to append a timestamp to akka-app's message envelopes
+addTimestampToAkkaMessages: true

--- a/lib/bbb/messages/OutMessage2x.js
+++ b/lib/bbb/messages/OutMessage2x.js
@@ -8,13 +8,19 @@
  * 2x model
  * @constructor
  */
+
+const config = require('config');
+const ADD_TIMESTAMP = config.has('addTimestampToAkkaMessages')
+  ? config.get('addTimestampToAkkaMessages')
+  : true;
+
 function OutMessage2x(messageName, routing, headerFields) {
 
 
     this.envelope = {
       name: messageName,
       routing: routing,
-      timestamp: Date.now() 
+      timestamp: ADD_TIMESTAMP? Date.now() : undefined,
     }
     /**
      * The header template of the message


### PR DESCRIPTION
Closes #151 and put it behind a configuration option.
New configs:
  -  `addTimestampToAkkaMessages`. Environment variable: `AKKA_MSG_TIMESTAMP`