### PR TITLE
Merge with 2.4.5

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -51,3 +51,5 @@ screenshareSubscriberSpecSlave: SCREENSHARE_SUBSCRIBER_SLAVE
 kurentoAllowedCandidateIps:
   __name: KURENTO_ALLOWED_CANDIDATE_IPS
   __format: json
+
+addTimestampToAkkaMessages: AKKA_MSG_TIMESTAMP

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -169,16 +169,16 @@ kurentoRembParams:
   upLosses: 12
   decrementFactor: 0.5
   thresholdFactor: 0.8
-# kurentoAllowedCandidateIps: optional configuration. List of VALID IPs to be used 
+# kurentoAllowedCandidateIps: optional configuration. List of VALID IPs to be used
 # to define valid outbound ICE candidates.
 # This is a short-term optimization to reduce the number of candidates sent to
 # the client by filtering out anything that isn't in this list
 kurentoAllowedCandidateIps:
   #- <ipv4|ipv6>
 
-# mediaThresholds: mandatory configuration. Establishes type-agnostic media thresholds 
-# that when hit will make the server refuse to negotiate new medias. 
-# Any attemps to inject medias past the thresholds will return an error with code 
+# mediaThresholds: mandatory configuration. Establishes type-agnostic media thresholds
+# that when hit will make the server refuse to negotiate new medias.
+# Any attemps to inject medias past the thresholds will return an error with code
 # 2002 and message MEDIA_SERVER_NO_RESOURCES.
 # The threshold priority order is global -> perRoom -> perUser. Value 0 means unlimited
 # (default). An optional API parameter may be sent on pub/sub calls (ignoreThresholds)
@@ -188,3 +188,5 @@ mediaThresholds:
   global: 0
   perRoom: 0
   perUser: 0
+# Whether to append a timestamp to akka-app's message envelopes
+addTimestampToAkkaMessages: true

--- a/lib/bbb/messages/OutMessage2x.js
+++ b/lib/bbb/messages/OutMessage2x.js
@@ -8,12 +8,19 @@
  * 2x model
  * @constructor
  */
+
+const config = require('config');
+const ADD_TIMESTAMP = config.has('addTimestampToAkkaMessages')
+  ? config.get('addTimestampToAkkaMessages')
+  : true;
+
 function OutMessage2x(messageName, routing, headerFields) {
 
 
     this.envelope = {
       name: messageName,
-      routing: routing 
+      routing: routing,
+      timestamp: ADD_TIMESTAMP? Date.now() : undefined,
     }
     /**
      * The header template of the message


### PR DESCRIPTION
Merge with patch release 2.4.5.

__CHANGELOG__:
  - Addressed https://github.com/mconf/bbb-webrtc-sfu/issues/151
    * Timestamps in akka-apps message envelopes are enabled by default. Can be controlled by `addTimestampToAkkaMessages` (config) or  `AKKA_MSG_TIMESTAMP` (environment variable).