### PR TITLE
Make webcam/video recording name depend only on BBB`s userId (#1

### DIFF
--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -259,7 +259,7 @@ module.exports = class Video extends BaseProvider {
     return new Promise(async (resolve, reject) => {
       try {
         const cameraCodec = DEFAULT_MEDIA_SPECS.codec_video_main;
-        const recordingName = this._cameraProfile + '-' + this.id;
+        const recordingName = `${this._cameraProfile}-${this.bbbUserId}`;
         const recordingProfile = (cameraCodec === 'VP8' || cameraCodec === 'ANY')
           ? C.RECORDING_PROFILE_WEBM
           : C.RECORDING_PROFILE_MKV;


### PR DESCRIPTION
VideoManager`s index is not used for it anymore. Timestamp still appended, will differentiante stuff.
Closes #168.