### PR TITLE
[lt246-3] Load testing follow up #3 for v2.4.6 and close release

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -207,3 +207,11 @@ mediaThresholds:
   perUser: 0
 # Whether to append a timestamp to akka-app's message envelopes
 addTimestampToAkkaMessages: true
+# Whether to allow duplicate externalUserId's on join. If allowed, join requests with
+# a externalUserId specified in the optional parameters will associate the new connection
+# with a pre-existing user (if it exists), or create a new one.
+# This will create a new virtual link between the request
+# and the pre-existing user with a unique internal user ID. The user will be
+# cleared from the system when a leave call for it is sent OR it has the autoLeave
+# optional parameter set to true and all of its medias were cleared
+allowDuplicateExtUserId: true

--- a/lib/audio/AudioManager.js
+++ b/lib/audio/AudioManager.js
@@ -100,7 +100,7 @@ module.exports = class AudioManager extends BaseManager {
           }), C.FROM_AUDIO);
         }
 
-        Logger.debug(this._logPrefix, 'Received start message', message, 'from connection', message.connectionId);
+        Logger.debug(this._logPrefix, 'Received start message', message, 'from connection', connectionId);
 
         if (session == null) {
           session = new Audio(this._bbbGW, voiceBridge, this.mcs, internalMeetingId);
@@ -119,14 +119,12 @@ module.exports = class AudioManager extends BaseManager {
 
         // starts audio session by sending sessionID, websocket and sdpoffer
         session.start(sessionId, connectionId, message.sdpOffer, message.caleeName, message.userId, message.userName, (error, sdpAnswer) => {
-          Logger.info(this._logPrefix, "Started presenter ", sessionId, " for connection", connectionId);
-          Logger.debug(this._logPrefix, "SDP answer was", sdpAnswer);
-
           if (error) {
             const errorMessage = this._handleError(this._logPrefix, connectionId, null, C.RECV_ROLE, error);
             return handleStartError(errorMessage);
           }
 
+          Logger.info(this._logPrefix, `Started listen only session for user ${message.userId} at ${sessionId} with connectionId ${connectionId}`);
           // Empty ice queue after starting audio
           this._flushIceQueue(session, iceQueue);
 
@@ -136,24 +134,24 @@ module.exports = class AudioManager extends BaseManager {
           });
 
           this._bbbGW.publish(JSON.stringify({
-            connectionId: connectionId,
+            connectionId,
             id : 'startResponse',
             type: 'audio',
             response : 'accepted',
             sdpAnswer : sdpAnswer
           }), C.FROM_AUDIO);
 
-          Logger.info(this._logPrefix, "Sending startResponse to user", sessionId, "for connection", session._id);
+          Logger.info(this._logPrefix, `Sending startResponse to user ${message.userId} at ${sessionId} with connectionId ${connectionId}`);
         });
         break;
 
       case 'stop':
-        Logger.info(this._logPrefix, 'Received stop message for session', sessionId, "at connection", connectionId);
+        Logger.info(this._logPrefix, `Received stop message for user ${message.userId} at ${sessionId} with connectionId ${connectionId}`);
 
         if (session) {
           session.stopListener(connectionId);
         } else {
-          Logger.warn(this._logPrefix, "There was no audio session on stop for", sessionId);
+          Logger.warn(this._logPrefix, `There was no audio session on stop for user ${message.userId} at ${sessionId} with connectionId ${connectionId}`);
         }
         break;
 

--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -5,6 +5,8 @@ const C = require('../bbb/messages/Constants');
 const Logger = require('../utils/Logger');
 const Messaging = require('../bbb/messages/Messaging');
 const BaseProvider = require('../base/BaseProvider');
+const errors = require('../base/errors.js');
+
 const LOG_PREFIX = "[audio]";
 
 const mediaFlowTimeoutDuration = config.get('mediaFlowTimeoutDuration');
@@ -60,10 +62,8 @@ module.exports = class Audio extends BaseProvider {
         this.mcs.addIceCandidate(this.audioEndpoints[connectionId], _candidate);
       }
       catch (error)   {
-        const userId = this.getUser(connectionId);
         Logger.error(LOG_PREFIX, "ICE candidate could not be added to media controller.",
           { ...this._getFullLogMetadata(connectionId), error });
-        this._handleError(LOG_PREFIX, error, "recv", userId);
       }
     }
     else {
@@ -86,7 +86,6 @@ module.exports = class Audio extends BaseProvider {
         }
       }
       catch (error) {
-        const userId = this.getUser(connectionId);
         Logger.error(LOG_PREFIX, "ICE candidate could not be added to media controller.",
           { ...this._getFullLogMetadata(connectionId), error });
       }
@@ -100,7 +99,7 @@ module.exports = class Audio extends BaseProvider {
    * @param  {String} connectionId Current connection id at the media manager
    * @param  {Object} user {userId: String, userName: String}
    */
-  addUser(connectionId, user) {
+  addUser (connectionId, user) {
     if (this.connectedUsers.hasOwnProperty(connectionId)) {
       Logger.warn(LOG_PREFIX, `Updating user for connectionId ${connectionId}`,
         this._getFullLogMetadata(connectionId));
@@ -110,14 +109,18 @@ module.exports = class Audio extends BaseProvider {
       this._getFullLogMetadata(connectionId));
   };
 
-/**
- * Exclude user from a hash object indexed by it's connectionId
- * @param  {String} connectionId Current connection id at the media manager
- */
+  static isValidUser (user) {
+    return user && user.userId && user.userName;
+  }
+
+  /**
+   * Exclude user from a hash object indexed by it's connectionId
+   * @param  {String} connectionId Current connection id at the media manager
+   */
   removeUser(connectionId) {
-    Logger.debug(LOG_PREFIX, `Removing user with connectionId ${connectionId}`,
-      this._getFullLogMetadata(connectionId));
     if (this.connectedUsers.hasOwnProperty(connectionId)) {
+      Logger.info(LOG_PREFIX, `Removing user with connectionId ${connectionId}`,
+        this._getFullLogMetadata(connectionId));
       delete this.connectedUsers[connectionId];
     } else {
       Logger.error(LOG_PREFIX, `User not found on remove for connectionId ${connectionId}`,
@@ -203,7 +206,6 @@ module.exports = class Audio extends BaseProvider {
       connectionId,
       id : 'iceCandidate',
       type: 'audio',
-      cameraId: this._id,
       candidate : candidate
     }), C.FROM_AUDIO);
   }
@@ -295,7 +297,12 @@ module.exports = class Audio extends BaseProvider {
         this._getPartialLogMetadata());
       try {
         if (!this.sourceAudioStarted && this.sourceAudioStatus === C.MEDIA_STOPPED) {
-          this.userId = await this.mcs.join(this.voiceBridge, 'SFU', { name: calleeName });
+          const userId = await this.mcs.join(
+            this.voiceBridge,
+            'SFU',
+            { name: calleeName },
+          );
+          this.userId = userId;
           Logger.info(LOG_PREFIX, `MCS join for PROXY_${calleeName} returned ${this.userId}`,
             { ...this._getPartialLogMetadata(), userId: this.userId });
           const globalAudioOptions = {
@@ -348,7 +355,7 @@ module.exports = class Audio extends BaseProvider {
           this.sourceAudioStatus = C.MEDIA_STARTED;
           this.emit(C.MEDIA_STARTED);
 
-          Logger.info(LOG_PREFIX, `Listen only source RTP relay sucessfully created`,
+          Logger.info(LOG_PREFIX, `Listen only source RTP relay successfully created`,
             { ...this._getPartialLogMetadata(), mediaId: this.sourceAudio, userId: this.userId });
           return resolve();
         }
@@ -362,14 +369,21 @@ module.exports = class Audio extends BaseProvider {
 
   async start (sessionId, connectionId, sdpOffer, calleeName, userId, userName, callback) {
     try {
-      const mcsUserId = await this.mcs.join(this.voiceBridge, 'SFU', { userId, name: userName });
+      const mcsUserId = await this.mcs.join(
+        this.voiceBridge,
+        'SFU',
+        { externalUserId: userId, name: userName , autoLeave: true }
+      );
       // Storing the user data to be used by the pub calls
       const user = { userId, userName, mcsUserId };
       this.addUser(connectionId, user);
       Logger.info(LOG_PREFIX, `Starting new listen only session`,
         this._getFullLogMetadata(connectionId));
       const sdpAnswer = await this._subscribeToGlobalAudio(sdpOffer, connectionId);
-      return callback(null, sdpAnswer);
+      // Check for stop while starting glare. If the user doesn't exist anymore,
+      // that's the case. Clean mcs-core's stuff up.
+      const maybeError = await this._checkForStopGlare(connectionId);
+      return callback(maybeError, sdpAnswer);
     }
     catch (error) {
       Logger.error(LOG_PREFIX, `Error on starting new listen only session, rejecting it...`,
@@ -377,6 +391,29 @@ module.exports = class Audio extends BaseProvider {
       return callback(this._handleError(LOG_PREFIX, error, "recv", userId));
     }
   };
+
+  async _checkForStopGlare (connectionId) {
+    const user = this.getUser(connectionId);
+    if (!Audio.isValidUser(user)) {
+      Logger.warn(LOG_PREFIX, `Session was stopped while starting, clean things up`,
+        this._getFullLogMetadata(connectionId));
+
+      try {
+        await this.stopListener(connectionId);
+      } catch (error) {
+        Logger.warn(LOG_PREFIX, `Error while rolling back at _checkForStopGlare`,
+          { ...this._getFullLogMetadata(connectionId), error });
+      }
+
+      // Glare detected. The session has been properly cleaned. Return a standardized
+      // MEDIA_NOT_FOUND
+      const error = { code: 2201, reason: errors[2201] };
+      return this._handleError(LOG_PREFIX, error, "recv", connectionId);
+    } else {
+      // There's no glare. Return null (means no error)
+      return null;
+    }
+  }
 
   _subscribeToGlobalAudio (sdpOffer, connectionId) {
     return new Promise(async (resolve, reject) => {
@@ -390,8 +427,15 @@ module.exports = class Audio extends BaseProvider {
             ignoreThresholds: true,
           }
 
-          const { mediaId, answer } = await this.mcs.subscribe(mcsUserId,
-            this.sourceAudio, C.WEBRTC, options);
+          let mediaId, answer;
+          try {
+            ({ mediaId, answer } = await this.mcs.subscribe(mcsUserId,
+              this.sourceAudio, C.WEBRTC, options));
+          } catch (subscribeError) {
+            Logger.error(LOG_PREFIX, `New listen only session failed to subscribe to GLOBAL_AUDIO`,
+              { ...this._getPartialLogMetadata(), subscribeError});
+            return reject(this._handleError(LOG_PREFIX, subscribeError, "recv", connectionId));
+          }
 
           this.mcs.onEvent(C.MEDIA_STATE, mediaId, (event) => {
             this._mediaStateWebRTC(event, mediaId, connectionId);
@@ -403,7 +447,7 @@ module.exports = class Audio extends BaseProvider {
 
           this.audioEndpoints[connectionId] = mediaId;
           this._flushCandidatesQueue(connectionId);
-          Logger.info(LOG_PREFIX, `Listen only session sucessfully subscribed to global audio with MCS user ${mcsUserId}`,
+          Logger.info(LOG_PREFIX, `Listen only session successfully subscribed to global audio with MCS user ${mcsUserId}`,
             this._getFullLogMetadata(connectionId));
           resolve(answer);
         }
@@ -437,15 +481,6 @@ module.exports = class Audio extends BaseProvider {
         await this.mcs.unsubscribe(mcsUserId, listener);
       } catch (error) {
         Logger.warn(LOG_PREFIX, `Error on unsubscribing listener media ${listener}`,
-          { ...this._getFullLogMetadata(connection), error});
-      }
-    }
-
-    if (mcsUserId) {
-      try {
-        await this.mcs.leave(this.voiceBridge, mcsUserId);
-      } catch (error) {
-        Logger.warn(LOG_PREFIX, `Error on leave for listen only session ${listener}}`,
           { ...this._getFullLogMetadata(connectionId), error});
       }
     }

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -32,6 +32,7 @@ const config = require('config');
 
         // Provider events
         VIDEO_SOURCE_ADDED: "videoSourceAdded",
+        VIDEO_NEGOTIATED: "videoNegotiated",
         VIDEO_STOPPED: "videoStopped",
 
         // Redis channels
@@ -205,6 +206,8 @@ const config = require('config');
         MEDIA_STATE_ICE: 'onIceCandidate',
 
         MEDIA_STARTED: 'MEDIA_STARTED',
+        MEDIA_NEGOTIATED: 'MEDIA_NEGOTIATED',
+        MEDIA_NEGOTIATION_FAILED: 'MEDIA_NEGOTIATION_FAILED',
         MEDIA_STOPPED: 'MEDIA_STOPPED',
         MEDIA_STOPPING: "MEDIA_STOPPING",
         MEDIA_STARTING: 'MEDIA_STARTING',

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -38,21 +38,21 @@ const MR = class MCSRouter {
     return this._mediaController.stop();
   }
 
-  join (roomId, type, clientTrackingId, params) {
+  join (roomId, type, params) {
     try {
-      return this._mediaController.join(roomId, type, clientTrackingId, params);
+      return this._mediaController.join(roomId, type, params);
     }
     catch (error) {
-      throw (this._handleError(error, 'join', { roomId, type, clientTrackingId, params }));
+      throw (this._handleError(error, 'join', { roomId, type, params }));
     }
   }
 
-  leave (roomId, userId, clientTrackingId) {
+  leave (roomId, userId, params = {}) {
     try {
-      return this._mediaController.leave(roomId, userId, clientTrackingId);
+      return this._mediaController.leave(roomId, userId, params);
     }
     catch (error) {
-      throw (this._handleError(error, 'leave', { userId, roomId, clientTrackingId }));
+      throw (this._handleError(error, 'leave', { userId, roomId, }));
     }
   }
 
@@ -357,7 +357,7 @@ const MR = class MCSRouter {
       try {
         Logger.info(LOG_PREFIX, `Closing user ${session.userId} session due to a client disconnection`,
           { roomId: session.roomId, userId: session.userId, clientTrackingId: session.clientTrackingId });
-        this.leave(session.roomId, session.userId, session.clientTrackingId);
+        this.leave(session.roomId, session.userId);
       } catch (e) {
         this._handleError(e, 'leave');
       }
@@ -392,7 +392,7 @@ const MR = class MCSRouter {
       let transactionId, room_id, type, params;
       try {
         ({ transactionId, room_id, type, params } = args);
-        const userId = this.join(room_id, type, client.trackingId, params);
+        const userId = this.join(room_id, type, params);
         client.joined(userId, { transactionId });
         client.userSessions.push({ userId, roomId: room_id, clientTrackingId: client.trackingId });
       } catch (e) {
@@ -533,10 +533,10 @@ const MR = class MCSRouter {
     });
 
     client.on('leave', (args) => {
-      let userId, roomId, transactionId;
+      let userId, roomId, transactionId, params;
       try {
-        ({ userId, roomId, transactionId } = args);
-        this.leave(roomId, userId, client.trackingId);
+        ({ userId, roomId, transactionId, params } = args);
+        this.leave(roomId, userId, params);
         client.left(userId, { transactionId });
       } catch (e) {
         this._notifyMethodError(client, e, transactionId);

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -12,6 +12,9 @@ const AdapterFactory = require('../adapters/adapter-factory');
 const StrategyManager = require('./strategy-manager.js');
 const MediaFactory = require('./media-factory.js');
 const { global: GLOBAL_MEDIA_THRESHOLD } = config.get('mediaThresholds');
+const ALLOW_DUPLICATE_EXT_USER_ID = config.has('allowDuplicateExtUserId')
+  ? config.get('allowDuplicateExtUserId')
+  : true;
 
 const LOG_PREFIX = "[mcs-controller]";
 
@@ -29,6 +32,7 @@ module.exports = class MediaController {
       this.mediaSessions = [];
       this.medias = [];
       this.strategyManager = new StrategyManager();
+      this._ejectUser = this._ejectUser.bind(this);
       instance = this;
     }
     return instance;
@@ -86,13 +90,12 @@ module.exports = class MediaController {
     });
   }
 
-  join (roomId, type, clientTrackingId, params) {
+  join (roomId, type, params) {
     try {
       const room = this.createRoom(roomId);
       // Inherit strategy from room unless it was directly specified
       params.strategy = params.strategy || room.strategy;
-      const user = this.createUser(roomId, type, clientTrackingId, params);
-      room.addUser(user);
+      const user = this.createUser(room, type, params);
       Logger.info(LOG_PREFIX, `User ${user.id} joined room ${roomId} as ${type}`);
       return user.id;
     } catch (e) {
@@ -102,8 +105,9 @@ module.exports = class MediaController {
   }
 
   _leave (room, user) {
-    try {
-      const killedMedias = user.leave();
+    const { id: userId, externalUserId } = user;
+    Logger.info(LOG_PREFIX, `User ${userId}  actually leaving`, { userId, externalUserId });
+    user.leave().then((killedMedias) => {
       killedMedias.forEach((mediaId) => {
         try {
           this.removeMediaSession(mediaId);
@@ -119,17 +123,27 @@ module.exports = class MediaController {
 
       Logger.trace(LOG_PREFIX, 'Active media sessions', this.mediaSessions.map(ms => ms.id));
       Logger.trace(LOG_PREFIX, "Active users", this.users.map(u => u.id));
-    } catch (err) {
+    }).catch(err => {
       throw (this._handleError(err));
+    });
+  }
+
+  _ejectUser (userInfo) {
+    const { userId, externalUserId, roomId } = userInfo;
+    try {
+      this.leave(roomId, userId, C.INTERNAL_TRACKING_ID)
+    } catch (error) {
+      Logger.error(LOG_PREFIX, `Auto eject for user ${userId} at ${roomId} failed due to ${error.message}`,
+        { roomId, userId, externalUserId, error });
     }
   }
 
-  leave (roomId, userId, clientTrackingId) {
-    Logger.info(LOG_PREFIX, `User wants to leave room`, { userId, roomId, clientTrackingId });
+  leave (roomId, userId, params = {}) {
     let user, room;
     try {
-      room = this.getRoom(roomId);
       user = this.getUser(userId);
+      Logger.info(LOG_PREFIX, `User ${userId}  wants to leave`, { userId, externalUserId: user.externalUserId });
+      room = this.getRoom(user.roomId);
     } catch (error) {
       // User or room were already closed or not found, resolving as it is
       const normalizedError = this._handleError(error);
@@ -137,15 +151,11 @@ module.exports = class MediaController {
       throw (normalizedError);
     }
 
-    const remainingClients = user.deleteClientTrackingId(clientTrackingId);
-    Logger.info(LOG_PREFIX, `There are ${remainingClients.length} clients tethered to ${userId} on leave`);
-    if (remainingClients.length <= 0) {
-      try  {
-        this._leave(room, user);
-      } catch (error) {
-        Logger.warn(LOG_PREFIX, `Leave for ${userId} failed due to ${error.message}`, { roomId, userId, error });
-        throw error;
-      }
+    try  {
+      this._leave(room, user);
+    } catch (error) {
+      Logger.warn(LOG_PREFIX, `Leave for ${userId} failed due to ${error.message}`, { roomId, userId, error });
+      throw error;
     }
 
     return;
@@ -521,31 +531,43 @@ module.exports = class MediaController {
     return room;
   }
 
+
   /**
    * Creates an {User} of type @type
    * @param {String} roomId
    */
-  createUser (roomId, type, clientTrackingId, params)  {
-    const { userId }  = params;
+  createUser (room, type, params)  {
+    const { externalUserId }  = params;
+    const roomId = room.id;
     let user;
 
-    if (userId) {
+    if (externalUserId) {
       try {
-        user = this.getUser(userId);
-        user.addClientTrackingId(clientTrackingId);
+        user = this.getUser(externalUserId);
+        // If user is found and duplicate EXT_USER_IDs aren't allowed, throw error
+        if (!ALLOW_DUPLICATE_EXT_USER_ID) {
+          throw this._handleError({
+            ...C.ERROR.MEDIA_INVALID_OPERATION,
+            details: `externalUserId specified on join and duplicate externalUserId is not allowed`,
+          });
+        }
         return user;
       } catch (e) {
         // User was not found, just ignore it and create a new one
       }
     }
 
-    // No pre-existing userId sent in the join procedure, create a new one
-    user = new User(roomId, type, clientTrackingId, params);
+    // No pre-existing externalUserId sent in the join procedure, create a new one
+    user = new User(roomId, type, params);
     this.users.push(user);
+    room.addUser(user);
     Logger.info(LOG_PREFIX, `New user created at room ${roomId} with id ${user.id}`,
-      { roomId, userId: user.id });
+      { roomId, userId: user.id, externalUserId: user.externalUserId });
     // This event handler will be get rid of once the user is destroyed, so it's
     // no biggie it isn't explicitly removed
+    if (user.autoLeave) {
+      user.once(C.EVENT.EJECT_USER, this._ejectUser);
+    }
     return user;
   }
 
@@ -572,7 +594,8 @@ module.exports = class MediaController {
   }
 
   getUser (userId) {
-    const user = this.users.find(u => u.id === userId);
+    const user = this.users.find(u => u.id === userId)
+      || this.users.find(u => u.externalUserId === userId);
 
     if (user == null) {
       throw C.ERROR.USER_NOT_FOUND;
@@ -865,7 +888,7 @@ module.exports = class MediaController {
     try {
       const { roomId, userId, userName, sdpOffer, sdpAnswer, media } = event;
       const room = await this.createRoom(roomId);
-      const user = await this.createUser(roomId, C.USERS.SFU, C.USERS.INTERNAL_TRACKING_ID, { userId, name: userName });
+      const user = await this.createUser(room, C.USERS.SFU, { userId, name: userName });
       const session = user.createMediaSession(sdpOffer, C.MEDIA_TYPE.WEBRTC);
       session.sessionStarted();
       room.addMediaSession(session);

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -7,6 +7,7 @@
 
 const config = require('config');
 const rid = require('readable-id');
+const EventEmitter = require('events').EventEmitter;
 const C = require('../constants/constants.js');
 const Logger = require('../utils/logger.js');
 const MediaFactory = require('../media/media-factory.js');
@@ -17,17 +18,18 @@ const { perUser: USER_MEDIA_THRESHOLD } = config.get('mediaThresholds');
 
 const LOG_PREFIX = "[mcs-user]";
 
-module.exports = class User {
-  constructor(roomId, type, clientTrackingId, params = {}) {
-    this.id = params.userId? params.userId : rid();
+module.exports = class User extends EventEmitter  {
+  constructor(roomId, type, params = {}) {
+    super();
+    this.id = rid();
+    this.externalUserId = params.externalUserId || this.id;
+    this.autoLeave = typeof params.autoLeave !== 'undefined'? params.autoLeave : false;
     this.roomId = roomId;
     this.type = type;
     this.name = params.name ? params.name : this.id;
     this.mediaSessions = {}
     this._strategy = params.strategy || C.STRATEGIES.FREEWILL;
     this._clientTrackingIds = {};
-    this.addClientTrackingId(clientTrackingId);
-
   }
 
   set strategy (strategy) {
@@ -44,42 +46,25 @@ module.exports = class User {
     return this._strategy;
   }
 
-  addClientTrackingId (clientTrackingId = C.USERS.INTERNAL_TRACKING_ID) {
-    if (this._clientTrackingIds[clientTrackingId] == null) {
-      this._clientTrackingIds[clientTrackingId] = 1;
-      return;
-    }
-
-    this._clientTrackingIds[clientTrackingId] += 1
-
-  }
-
-  hasClientTrackingId (clientTrackingId) {
-    return this._clientTrackingIds[clientTrackingId];
-  }
-
-  deleteClientTrackingId (clientTrackingId) {
-    if (this._clientTrackingIds[clientTrackingId]) {
-      const numberOfBindedClients = --this._clientTrackingIds[clientTrackingId];
-      if (numberOfBindedClients <= 0) {
-        delete this._clientTrackingIds[clientTrackingId];
-      }
-    }
-    const remainingClients = Object.keys(this._clientTrackingIds);
-    return remainingClients;
-  }
-
-  _startSession (sessionId) {
+  async _startSession (sessionId) {
     const session = this.mediaSessions[sessionId];
     try {
       session.start();
-      return session.process();
+      const answer = await session.process();
+      return answer;
     } catch (error) {
-      this.stopSession(sessionId).catch(error => {
-        Logger.error(LOG_PREFIX, `CRITICAL: error when rolling back failed session start`,
-          { userId: this.id, roomId: this.roomId, mediaSessionId: sessionId });
-      });
-      throw error;
+      return this.stopSession(sessionId)
+        .then(() => {
+          Logger.info(LOG_PREFIX, `Media session ${sessionId} stopped and rolled back due to ${error.message}`,
+            { userId: this.id, roomId: this.roomId, mediaSessionId: sessionId, error });
+        })
+        .catch(rollbackError => {
+          Logger.error(LOG_PREFIX, `CRITICAL: stop and rollback for ${sessionId} failed due to ${rollbackError.message}`,
+            { userId: this.id, roomId: this.roomId, mediaSessionId: sessionId, error: rollbackError});
+        })
+        .finally(() => {
+          throw error;
+        });
     }
   }
 
@@ -198,12 +183,21 @@ module.exports = class User {
     }
   }
 
+  _ejectIfNeeded () {
+    if (this.autoLeave && Object.keys(this.mediaSessions).length <= 0) {
+      Logger.info(LOG_PREFIX, `User ${this.id} has autoLeave on and no medias, will be ejected`,
+        { userId: this.id, externalUserId: this.externalUserId, roomId: this.roomId });
+      this.emit(C.EVENT.EJECT_USER, this.getUserInfo());
+    }
+  }
+
   stopSession (sessionId) {
     const session = this.mediaSessions[sessionId];
     try {
       if (session) {
         Logger.info(LOG_PREFIX, `Stopping media session ${sessionId}`);
         delete this.mediaSessions[sessionId];
+        this._ejectIfNeeded();
         return session.stop();
       }
       return Promise.resolve();
@@ -236,25 +230,23 @@ module.exports = class User {
     const sessions = Object.keys(this.mediaSessions);
     Logger.info("[mcs-sfu-user] User", this.id, "wants to leave and its media sessions will be killed");
 
-    try {
-      sessions.forEach(async sk => {
-        try {
-          await this.stopSession(sk);
-        } catch (e) {
+    return sessions.reduce((promise, sk) => {
+      return promise.then(() => {
+        this.stopSession(sk).catch((e) => {
           // Error on stopping, it was probably a MEDIA_NOT_FOUND error, hence
           // we just delete the session if it's still allocated
-          this._handleError(e);
           if (this.mediaSessions[sk]) {
             delete this.mediaSessions[sk];
           }
-        }
+        });
       });
-
+    }, Promise.resolve()).then(() => {
       return sessions;
-    }
-    catch (err) {
-      throw (this._handleError(err));
-    }
+    }).catch(error => {
+      const normalizedError = this._handleError(error);
+      Logger.error(LOG_PREFIX, `CRITICAL: unrecoverable error on leave for user ${this.id}: ${normalizedError.message}`,
+        { error: normalizedError });
+    });
   }
 
   getMediaSession (id) {
@@ -270,6 +262,7 @@ module.exports = class User {
     const userInfo = {
       memberType: C.MEMBERS.USER,
       userId: this.id,
+      externalUserId: this.externalUserId,
       name: this.name,
       type: this.type,
       roomId: this.roomId,
@@ -298,7 +291,8 @@ module.exports = class User {
           GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, mediaSession.getMediaInfo());
         }
 
-        delete this.mediaSessions[mediaSessionId] ;
+        delete this.mediaSessions[mediaSessionId];
+        this._ejectIfNeeded();
         GLOBAL_EVENT_EMITTER.removeListener(C.EVENT.MEDIA_DISCONNECTED, deleteMedia);
       }
     };

--- a/lib/screenshare/ScreenshareManager.js
+++ b/lib/screenshare/ScreenshareManager.js
@@ -176,23 +176,31 @@ module.exports = class ScreenshareManager extends BaseManager {
     }
   }
 
-  async closeSession (session, connectionId, role, sessionId) {
+  closeSession (session, connectionId, role, sessionId) {
     if (session && session.constructor == Screenshare) {
-      if (role === C.SEND_ROLE && session) {
-        Logger.info(this._logPrefix, "Stopping presenter " + sessionId);
-        await this._stopSession(sessionId);
-        return;
+      if (role === C.SEND_ROLE) {
+        if (session) {
+          Logger.info(this._logPrefix, `Stopping screensharing presenter session ${sessionId}`);
+          return this._stopSession(sessionId).then(() => {
+            this._deleteIceQueue(sessionId);
+          });
+        }
+        // Delete ice queue for main session async despite having a session or not
+        // to avoid piling up ICE candidates from outdated sessions. This can happen
+        // because this thing is a mess.
+        this._deleteIceQueue(sessionId);
+        return Promise.resolve();
       }
+
       if (role === C.RECV_ROLE && session) {
-        Logger.info(this._logPrefix, "Stopping viewer ", sessionId);
-        await session.stopViewer(connectionId);
+        Logger.info(this._logPrefix, `Stopping screensharing viewer at ${sessionId} with connectionId ${connectionId}`);
+        return session.stopViewer(connectionId);
       }
+
+      return Promise.resolve();
     }
-    // Delete ice queue for main session async despite having a session or not
-    // to avoid piling up ICE candidates from outdated sessions. This can happen
-    // because this thing is a mess.
-    if (role === C.SEND_ROLE) {
-      this._deleteIceQueue(sessionId);
-    }
+
+    Logger.warn(this._logPrefix, `No screensharing session found for ${sessionId} with connectionId ${connectionId} and role ${role}`);
+    return Promise.resolve();
   }
-};
+}

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -416,11 +416,11 @@ module.exports = class Screenshare extends BaseProvider {
   _startPresenter (sdpOffer, userId, bbbUserName) {
     return new Promise(async (resolve, reject) => {
       try {
-        this.presenterMCSUserId = await this.mcs.join(
+        const presenterMCSUserId = await this.mcs.join(
           this._voiceBridge,
           'SFU',
-          { userId, name: bbbUserName }
-        );
+          { externalUserId: userId, name: bbbUserName, autoLeave: true });
+        this.presenterMCSUserId = presenterMCSUserId;
         const presenterSdpAnswer = await this._publishPresenterWebRTCStream(sdpOffer);
         await this.mcs.setContentFloor(this._voiceBridge, this._presenterEndpoint);
         resolve(presenterSdpAnswer);
@@ -531,15 +531,14 @@ module.exports = class Screenshare extends BaseProvider {
 
   _startViewer(connectionId, voiceBridge, sdpOffer, userId, presenterEndpoint, bbbUserName) {
     return new Promise(async (resolve, reject) => {
-      let sdpAnswer, mcsUserId;
+      let sdpAnswer;
       this._viewersCandidatesQueue[connectionId] = [];
 
       try {
-        mcsUserId = await this.mcs.join(
+        const mcsUserId = await this.mcs.join(
           this._voiceBridge,
           'SFU',
-          { userId, name: bbbUserName }
-        );
+          { externalUserId: userId, name: bbbUserName, autoLeave: true });
         this._viewerUsers[connectionId] = { userId, connectionId };
 
         // Get the REMB spec to be used. Screenshare uses the default mixed in with
@@ -656,44 +655,45 @@ module.exports = class Screenshare extends BaseProvider {
     }
   }
 
-  async stopViewer(id) {
+  stopViewer (id) {
     const viewerUser = this._viewerUsers[id];
     if (viewerUser == null) {
-      this._viewersCandidatesQueue[id] = null;
-      this._viewerEndpoints[id] = null;
-      return;
+      // User doesn't exist. Probably a stop request glare
+      delete this._viewersCandidatesQueue[id];
+      delete this._viewerEndpoints[id];
+      return Promise.resolve();
     }
+
     const { userId } = viewerUser;
     const viewerMediaId = this._viewerEndpoints[id];
     Logger.info(LOG_PREFIX, `Stopping screenshare viewer ${userId}`,
       this._getFullViewerLogMetadata(id));
 
     if (viewerMediaId) {
-      try {
-        await this.mcs.unsubscribe(userId, viewerMediaId);
-      } catch (error) {
-        Logger.error(LOG_PREFIX, `Viewer unsubscribe failed for ${userId} due to ${error.message}`,
-          { ...this._getFullViewerLogMetadata(id), error });
-      }
+      return this.mcs.unsubscribe(userId, viewerMediaId)
+        .then(() => {
+          Logger.debug(LOG_PREFIX, `Screenshare viewer ${userId} stopped`,
+            this._getFullViewerLogMetadata(id));
+        })
+        .catch(error => {
+          Logger.error(LOG_PREFIX, `Viewer unsubscribe failed for ${userId} due to ${error.message}`,
+            { ...this._getFullViewerLogMetadata(id), error });
+        })
+        .finally(() => {
+          delete this._viewersCandidatesQueue[id];
+          delete this._viewerEndpoints[id];
+          delete this._viewerUsers[id];
+        });
+    } else {
+      Logger.warn(LOG_PREFIX, `Screenshare viewer ${userId} media ID not found, probably already released`,
+        this._getFullViewerLogMetadata(id));
+      return Promise.resolve();
     }
-
-    if (userId) {
-      try {
-        await this.mcs.leave(this._voiceBridge, userId);
-      } catch (error) {
-        Logger.error(LOG_PREFIX, `Viewer leave failed for ${userId} due to ${error.message}`,
-          { ...this._getFullViewerLogMetadata(id), error });
-      }
-    }
-
-    this._viewersCandidatesQueue[id] = null;
-    this._viewerEndpoints[id] = null;
-    return;
   }
 
   _stopAllViewers () {
     Object.keys(this._viewerUsers).forEach(async connectionId => {
-      this.stopViewer(connectionId);
+      await this.stopViewer(connectionId);
     });
   }
 
@@ -785,14 +785,8 @@ module.exports = class Screenshare extends BaseProvider {
             this._ffmpegEndpoint = null;
           }
         }
-
-        try {
-          await this.mcs.leave(this._voiceBridge, this.presenterMCSUserId);
-        } catch (error) {
-          Logger.warn(LOG_PREFIX, `Leave failed for presenter ${this.presenterMCSUserId} due to ${error.message}`,
-            { ...this._getFullPresenterLogMetadata(this._connectionId), error });
-        }
       }
+
       this._stopAllViewers();
       delete sources[this._presenterEndpoint];
       this._presenterEndpoint = null;

--- a/lib/video/VideoManager.js
+++ b/lib/video/VideoManager.js
@@ -26,27 +26,10 @@ module.exports = class VideoManager extends BaseManager {
     this._trackExternalWebcamSources();
   }
 
-  _findByIdAndRole (id, role) {
-    let sesh = null;
-    let keys = Object.keys(this._sessions);
-    keys.forEach((sessionId) => {
-      let session = this._sessions[sessionId];
-      if (sessionId === (session.connectionId + id + '-' + role)) {
-        sesh = session;
-      }
-    });
-    return sesh;
-  }
-
-  setStreamAsRecorded (id) {
-    let video = this._findByIdAndRole(id, 'share');
-
-    if (video) {
-      Logger.info("[VideoManager] Setting ", id, " as recorded");
-      video.setStreamAsRecorded();
-    } else {
-      Logger.warn("[VideoManager] Tried to set stream to recorded but ", id, " has no session!");
-    }
+  static isVideoInstanceReady (video) {
+    return video
+      && video.constructor === Video
+      && (video.status !== C.MEDIA_STOPPED || video.status !== C.MEDIA_STOPPING);
   }
 
   async _onMessage (_message) {
@@ -66,9 +49,10 @@ module.exports = class VideoManager extends BaseManager {
       return;
     }
 
-    cameraId += '-' + role;
-
-    sessionId = connectionId + cameraId;
+    // !!!!!>>> BE AWARE OF THIS CODE. IT'S THE INDEX ASSEMBLY. MEDDLE WITH CARE <<<!!!!!
+    cameraId = `${cameraId}-${role}`;
+    sessionId = `${connectionId}-${cameraId}`;
+    // !!!!!>>> BE AWARE OF THIS CODE. IT'S THE INDEX ASSEMBLY. MEDDLE WITH CARE <<<!!!!!
 
     if (message.cameraId) {
       video = this._fetchSession(sessionId);
@@ -85,19 +69,37 @@ module.exports = class VideoManager extends BaseManager {
           if (video.status !== C.MEDIA_STARTING) {
             await this._stopSession(sessionId);
             const { voiceBridge } = message;
-            video = new Video(this._bbbGW, message.meetingId, message.cameraId,
-              shared, message.connectionId, this.mcs, voiceBridge, userId, userName);
+            video = new Video(
+              this._bbbGW,
+              message.meetingId,
+              message.cameraId,
+              shared,
+              message.connectionId,
+              this.mcs, voiceBridge,
+              userId,
+              userName,
+              sessionId,
+            );
             this._sessions[sessionId] = video;
           } else {
            return;
           }
         } else {
           const { voiceBridge } = message;
-          video = new Video(this._bbbGW, message.meetingId, message.cameraId,
-            shared, message.connectionId, this.mcs, voiceBridge, userId, userName);
+          video = new Video(
+            this._bbbGW,
+            message.meetingId,
+            message.cameraId,
+            shared,
+            message.connectionId,
+            this.mcs,
+            voiceBridge,
+            userId,
+            userName,
+            sessionId,
+          );
           this._sessions[sessionId] = video;
         }
-
 
         try {
           // Only apply bitrate cap to publishers.
@@ -144,6 +146,8 @@ module.exports = class VideoManager extends BaseManager {
         }).catch(error => {
           Logger.info(this._logPrefix, `Stopping session ${sessionId} failed due to ${error.message}.`,
             { error });
+        }).finally(() => {
+          this._deleteIceQueue(sessionId);
         });
         break;
 
@@ -154,10 +158,10 @@ module.exports = class VideoManager extends BaseManager {
         break;
 
       case 'onIceCandidate':
-        if (video && video.constructor === Video) {
+        if (VideoManager.isVideoInstanceReady(video)) {
           video.onIceCandidate(message.candidate);
         } else {
-          Logger.info(this._logPrefix, "Queueing ice candidate for later in video", cameraId);
+          Logger.info(this._logPrefix, "Queueing ice candidate for later in video", sessionId);
           iceQueue.push(message.candidate);
         }
         break;

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -19,11 +19,22 @@ const KURENTO_REMB_PARAMS = config.util.cloneDeep(config.get('kurentoRembParams'
 let sources = {};
 
 module.exports = class Video extends BaseProvider {
-  constructor(bbbGW, _meetingId, _id, _shared, _connectionId, mcs, voiceBridge, bbbUserId, bbbUserName) {
+  constructor(
+    bbbGW,
+    _meetingId,
+    _cameraId,
+    _shared,
+    _connectionId,
+    mcs,
+    voiceBridge,
+    bbbUserId,
+    bbbUserName,
+    managerSessionId,
+  ) {
     super(bbbGW);
     this.sfuApp = C.VIDEO_APP;
     this.mcs = mcs;
-    this.id = _id;
+    this.id = _cameraId;
     this.bbbUserId = bbbUserId;
     this.bbbUserName = bbbUserName;
     this.connectionId = _connectionId;
@@ -31,7 +42,8 @@ module.exports = class Video extends BaseProvider {
     this.voiceBridge = voiceBridge;
     this.shared = _shared;
     this.role = this.shared? 'share' : 'viewer'
-    this.streamName = this.connectionId + this.id + "-" + this.role;
+    this.managerSessionId = managerSessionId;
+    this.streamName = `${this.connectionId}${this.id}-${this.role}`;
     this.mediaId;
     this.status = C.MEDIA_STOPPED;
     this.recording = {};
@@ -43,7 +55,7 @@ module.exports = class Video extends BaseProvider {
     this.isRecording = false;
     this._startRecordingEventFired = false;
     this._stopRecordingEventFired = false;
-    this.pending = false;
+    this._stopActionQueued = false;
   }
 
   _getLogMetadata () {
@@ -59,15 +71,18 @@ module.exports = class Video extends BaseProvider {
 
   /* ======= EXTERNAL MEDIA SOURCE TRACKING ======= */
 
-  static setSource (userId, stream) {
-    Logger.info(LOG_PREFIX, "Setting new source media", userId, stream);
-    sources[userId] = stream;
-    emitter.emit(C.VIDEO_SOURCE_ADDED, userId);
+  static setSource (id, stream) {
+    Logger.info(LOG_PREFIX, `Setting new source media ${stream} of session ${id}`);
+    sources[id] = stream;
+    emitter.emit(C.VIDEO_SOURCE_ADDED, id);
   }
 
-  static removeSource (event) {
-    const { userId } = sourceMap;
-    sources[userId] = null;
+  static getSource (id) {
+    return sources[id];
+  }
+
+  static removeSource (id) {
+    delete sources[id];
   }
 
   mediaUserJoined (id) {
@@ -155,14 +170,12 @@ module.exports = class Video extends BaseProvider {
             delete this.notFlowingTimeout;
           }
           if (this.status !== C.MEDIA_STARTED) {
-
             // Record the video stream if it's the original being shared
             if (this.shouldRecord()) {
               this.startRecording();
             }
 
             this.sendPlayStart();
-
             this.status = C.MEDIA_STARTED;
           }
 
@@ -318,9 +331,22 @@ module.exports = class Video extends BaseProvider {
             this.isRecorded = await this.probeForRecordingStatus(this.meetingId, this.id);
           }
 
-          this.userId = await this.mcs.join(this.voiceBridge, 'SFU', { userId: this.bbbUserId, name: this.bbbUserName });
+          const userId = await this.mcs.join(
+            this.voiceBridge,
+            'SFU',
+            { externalUserId: this.bbbUserId, name: this.bbbUserName, autoLeave: true });
+          this.userId = userId;
           this.mediaUserJoined(this.streamName);
           const sdpAnswer = await this._addMCSMedia(C.WEBRTC, sdpOffer, mediaSpecs);
+          // Status to indicate that the brokering with mcs-core was succesfull.
+          // Don't mix with MEDIA_STARTED. MEDIA_STARTED means that media is
+          // flowing through the server. This just means that the session was
+          // negotiated properly.
+          this.status = C.MEDIA_NEGOTIATED;
+          // This event is used to handle stop requests that arrived while
+          // the media was still being negotiated with mcs-core.
+          // See Video#stop
+          emitter.emit(C.VIDEO_NEGOTIATED + this.streamName);
 
           this.mcs.onEvent(C.MEDIA_STATE, this.mediaId, (event) => {
             this._mediaStateWebRTC(event, this.mediaId);
@@ -336,8 +362,11 @@ module.exports = class Video extends BaseProvider {
           Logger.info(LOG_PREFIX, "Video start succeeded", this._getLogMetadata());
           return resolve(sdpAnswer);
         }
-        catch (err) {
-          reject(this._handleError(LOG_PREFIX, err, this.role, this.id));
+        catch (error) {
+          Logger.error(LOG_PREFIX, `Video start procedure failed due to ${error.message}`,
+            { ...this._getLogMetadata(), error });
+          this.status = C.MEDIA_NEGOTIATION_FAILED;
+          reject(this._handleError(LOG_PREFIX, error, this.role, this.id));
         }
       } else {
         const error = { code: 2200, reason: errors[2200] }
@@ -364,31 +393,23 @@ module.exports = class Video extends BaseProvider {
           }
           const { mediaId, answer } = await this.mcs.publish(this.userId, this.voiceBridge, type, options);
           this.mediaId = mediaId;
-          sources[this.id] = this.mediaId;
+          Video.setSource(this.id, this.mediaId);
           return resolve(answer);
         }
         else {
-          if (sources[this.id]) {
+          const stream = Video.getSource(this.id);
+          if (stream) {
             const answer = this._subscribeToMedia(descriptor, mediaSpecs);
             return resolve(answer);
           } else {
-            const lazySubscribe = (id) => {
-              if (id === this.id) {
-                const answer = this._subscribeToMedia(descriptor, mediaSpecs);
-                emitter.removeListener(C.VIDEO_SOURCE_ADDED, lazySubscribe);
-                return resolve(answer);
-              }
-            }
-            // Media not yet mapped, add it to pending list
-            // TODO implement a timeout to drop inactive candidates
-            Logger.warn(LOG_PREFIX, `Publisher stream from ${this.id} isn't set yet. Setting it up for a lazy subscription`, this._getLogMetadata());
-            emitter.on(C.VIDEO_SOURCE_ADDED, lazySubscribe);
+            const error = { code: 2201, reason: errors[2201] };
+            Logger.warn(LOG_PREFIX, `Publisher stream from ${this.id} isn't set yet. Rejecting with MEDIA_NOT_FOUND`,
+              this._getLogMetadata());
+            throw error;
           }
         }
-      }
-      catch (err) {
-        err = this._handleError(LOG_PREFIX, err, this.role, this.id)
-        reject(err);
+      } catch (error) {
+        return reject(error);
       }
     });
   }
@@ -408,9 +429,10 @@ module.exports = class Video extends BaseProvider {
         mediaSpecSlave: SUBSCRIBER_SPEC_SLAVE,
         kurentoRembParams,
       }
-      Logger.info(LOG_PREFIX, `Subscribing to stream ${sources[this.id]} from user ${this.id}`,
+      const stream = Video.getSource(this.id);
+      Logger.info(LOG_PREFIX, `Subscribing to stream ${stream} from user ${this.id}`,
         this._getLogMetadata());
-      const { mediaId, answer } = await this.mcs.subscribe(this.userId, sources[this.id], C.WEBRTC, options);
+      const { mediaId, answer } = await this.mcs.subscribe(this.userId, stream, C.WEBRTC, options);
       this.mediaId = mediaId;
       return answer;
     }
@@ -420,7 +442,7 @@ module.exports = class Video extends BaseProvider {
   }
 
   async pause (state) {
-    const sourceId = sources[this.id];
+    const stream = Video.getSource(this.id);
     const sinkId = this.mediaId;
 
     // TODO temporarily deactivated this procedure until the connection type param is fixed
@@ -430,11 +452,11 @@ module.exports = class Video extends BaseProvider {
     // We want to pause the stream
     try {
       if (state && (this.status !== C.MEDIA_STARTING || this.status !== C.MEDIA_PAUSED)) {
-        await this.mcs.disconnect(sourceId, sinkId, 'VIDEO');
+        await this.mcs.disconnect(stream, sinkId, 'VIDEO');
         this.status = C.MEDIA_PAUSED;
       }
       else if (!state && this.status === C.MEDIA_PAUSED) { //un-pause
-        await this.mcs.connect(sourceId, sinkId, 'VIDEO');
+        await this.mcs.connect(stream, sinkId, 'VIDEO');
         this.status = C.MEDIA_STARTED;
       }
     }
@@ -445,64 +467,59 @@ module.exports = class Video extends BaseProvider {
 
   /* ======= STOP METHODS ======= */
 
+  async _finishVideoSession (resolver) {
+    this.status = C.MEDIA_STOPPING;
+
+    try {
+      if (this.shouldRecord()
+        && this.isRecording
+        && this.state !== C.MEDIA_STOPPED) {
+        await this.stopRecording();
+      }
+    } catch (error) {
+      Logger.warn(LOG_PREFIX, `Error on stopping recording for user ${this.userId} with stream ${this.streamName}`,
+        { ...this._getLogMetadata(), error });
+    }
+
+    if (this.mediaId) {
+      if (this.shared) {
+        try {
+          await this.mcs.unpublish(this.userId, this.mediaId);
+        } catch (error) {
+          Logger.error(LOG_PREFIX, `Unpublish failed for user ${this.userId} with stream ${this.streamName}`,
+            { ...this._getLogMetadata(), error });
+        }
+        Video.removeSource(this.id);
+      } else {
+        try {
+          await this.mcs.unsubscribe(this.userId, this.mediaId);
+        } catch (error) {
+          Logger.error(LOG_PREFIX, `Unsubscribe failed for user ${this.userId} with stream ${this.streamName}`,
+            { ...this._getLogMetadata(), error }); }
+      }
+    }
+
+    if (this.notFlowingTimeout) {
+      clearTimeout(this.notFlowingTimeout);
+      delete this.notFlowingTimeout;
+    }
+
+    delete this.candidatesQueue;
+    emitter.emit(C.VIDEO_STOPPED + this.streamName);
+    this.status = C.MEDIA_STOPPED;
+    Logger.info(LOG_PREFIX, `Stopped video session ${this.streamName}`, this._getLogMetadata());
+    return resolver();
+  }
+
   async stop () {
     return new Promise(async (resolve, reject) => {
-      const finishVideoSession = async () => {
-        try {
-          if (this.shouldRecord() && this.isRecording && this.state !== C.MEDIA_STOPPED) {
-            await this.stopRecording();
-          }
-        } catch (error) {
-          Logger.warn(LOG_PREFIX, `Error on stopping recording for user ${this.userId} with stream ${this.streamName}`,
-            { ...this._getLogMetadata(), error });
-        }
-
-        this.status = C.MEDIA_STOPPING;
-
-        if (this.mediaId) {
-          if (this.shared) {
-            try {
-              await this.mcs.unpublish(this.userId, this.mediaId);
-            } catch (error) {
-              Logger.error(LOG_PREFIX, `Unpublish failed for user ${this.userId} with stream ${this.streamName}`,
-                { ...this._getLogMetadata(), error });
-            }
-            delete sources[this.id];
-          } else {
-            try {
-              await this.mcs.unsubscribe(this.userId, this.mediaId);
-            } catch (error) {
-              Logger.error(LOG_PREFIX, `Unsubscribe failed for user ${this.userId} with stream ${this.streamName}`,
-                { ...this._getLogMetadata(), error });
-            }
-          }
-        }
-
-        try {
-          await this.mcs.leave(this.voiceBridge, this.userId);
-        } catch (error) {
-          Logger.warn(LOG_PREFIX, `Leave failed for ${this.userId} at ${this.voiceBridge}`,
-            { ...this._getLogMetadata(), error });
-        }
-
-        if (this.notFlowingTimeout) {
-          clearTimeout(this.notFlowingTimeout);
-          delete this.notFlowingTimeout;
-        }
-
-        delete this.candidatesQueue;
-        emitter.emit(C.VIDEO_STOPPED + this.streamName);
-        this.status = C.MEDIA_STOPPED;
-
-        resolve();
-      }
-
       switch (this.status) {
         case C.MEDIA_STOPPED:
           Logger.warn(LOG_PREFIX, `Video session ${this.streamName} already stopped`,
             this._getLogMetadata());
           return resolve();
           break;
+
         case C.MEDIA_STOPPING:
           Logger.warn(LOG_PREFIX, `Video session ${this.streamName} already stopping`,
             this._getLogMetadata());
@@ -512,15 +529,37 @@ module.exports = class Video extends BaseProvider {
             return resolve();
           });
           break;
+
+        case C.MEDIA_STARTING:
+          Logger.warn(LOG_PREFIX, `Video session ${this.streamName} is still starting. Let it finish then stop it`,
+            this._getLogMetadata());
+          if (!this._stopActionQueued) {
+            this._stopActionQueued = true;
+            emitter.once(C.VIDEO_NEGOTIATED + this.streamName, () => {
+              Logger.info(LOG_PREFIX, `Calling delayed MEDIA_STARTING stop action for queued stop call for ${this.streamName}`,
+                this._getLogMetadata());
+              this._finishVideoSession(resolve);
+            });
+          } else {
+            emitter.once(C.VIDEO_STOPPED + this.streamName, () => {
+              Logger.info(LOG_PREFIX, `Calling delayed stop resolution for queued stop call for ${this.streamName}`,
+                this._getLogMetadata());
+              return resolve();
+            });
+          }
+          break;
+
         default:
           Logger.info(LOG_PREFIX, `Stopping video session ${this.streamName}`, this._getLogMetadata());
           if (this.userId == null) {
             Logger.info(LOG_PREFIX, `Video session ${this.streamName} stop glare`,
               this._getLogMetadata());
-            emitter.once(C.MEDIA_USER_JOINED + this.streamName, finishVideoSession.bind(this));
+            emitter.once(C.MEDIA_USER_JOINED + this.streamName, () => {
+              this._finishVideoSession(resolve);
+            });
           } else {
             // This method resolves this method's wrapping promise
-            finishVideoSession();
+            this._finishVideoSession(resolve);
           }
       }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.6-beta.4",
+  "version": "2.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.6-beta.4",
+  "version": "2.4.6",
   "private": true,
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
- Revert the user tether added in #121 in favour of a configurable duplicate externalUserId approach
- Added autoLeave optional parameter to mcs-core`s join
- Re-sanitize all leave procedures on video/screenshare/audio and use autoLeave and externalUserId
- Properly rollback media process failures in mcs-core
- Handle stop while starting glare in audio/video providers
- Some scattered log improvements