### PR TITLE
Update H264 video configuration

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -140,8 +140,8 @@ conference-media-specs:
   codec_audio: "ANY"
   H264:
     profile_level_id: "42e01f"
-    packetization_mode: "0"
-    level_asymmetry_allowed: "0"
+    packetization_mode: "1"
+    level_asymmetry_allowed: "1"
     tias_main: "300000"
     as_main: "300"
     tias_content: "1500000"


### PR DESCRIPTION
This makes H264 video playback working again in Firefox