### PR TITLE
Implement getMedias API call

### DIFF
--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -340,6 +340,16 @@ const MR = class MCSRouter {
     }
   }
 
+  getMedias (args) {
+    const { memberType, identifier, options } = args
+    try {
+      return this._mediaController.getMedias(memberType, identifier, options)
+    }
+    catch (error) {
+      throw (this._handleError(error, 'getMedias', { memberType, identifier }));
+    }
+  }
+
   _notifyMethodError (client, error, transactionId = null) {
     client.error(error, { transactionId });
   }
@@ -725,6 +735,18 @@ const MR = class MCSRouter {
         ({ transactionId, mediaId } = args);
         await this.requestKeyframe(args);
         client.keyframeRequested(mediaId, { transactionId });
+      }
+      catch (e) {
+        this._notifyMethodError(client, e, transactionId)
+      }
+    });
+
+    client.on('getMedias', (args) =>{
+      let transactionId;
+      try {
+        ({ transactionId } = args);
+        const medias = this.getMedias(args);
+        client.getMediasResponse(medias, { transactionId });
       }
       catch (e) {
         this._notifyMethodError(client, e, transactionId)

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -650,10 +650,21 @@ module.exports = class MediaController {
   getUserMedias (userId) {
     try {
       const user = this.getUser(userId);
-      return user.getUserMedias();
+      return user.getMediaInfos();
     } catch (error) {
       Logger.error(LOG_PREFIX, `getUserMedias failed for user ${userId} due to ${error.message}`,
         { userId, error });
+      throw (this._handleError(error));
+    }
+  }
+
+  getRoomMedias (roomId) {
+    try {
+      const room = this.getRoom(roomId);
+      return room.getMediaInfos();
+    } catch (error) {
+      Logger.error(LOG_PREFIX, `getRoomMedias failed for room ${roomId} due to ${error.message}`,
+        { roomID, error });
       throw (this._handleError(error));
     }
   }
@@ -890,6 +901,24 @@ module.exports = class MediaController {
     }
   }
 
+  _getMediasByMemberIdentifier (memberType, identifier) {
+    switch (memberType) {
+      case C.MEMBERS.USER:
+        return this.getUserMedias(identifier);
+      case C.MEMBERS.ROOM:
+        return this.getRoomMedias(identifier);
+      case C.MEMBERS.MEDIA_SESSION:
+        return this.getMediaSession(identifier).getMediaInfo();
+      case C.MEMBERS.MEDIA:
+        return this.getMedia(identifier).getMediaInfo();
+      default:
+        throw (this._handleError({
+          ...C.ERROR.MEDIA_INVALID_TYPE,
+          details: `getMedias memberType is invalid: ${memberType}`,
+        }));
+    }
+  }
+
   // FIXME
   // this is temporary workaround to create a media that joined freeswitch externally
   _handleExternalAudioMediaConnected (event) {
@@ -948,6 +977,45 @@ module.exports = class MediaController {
       return mediaSession.requestKeyframe();
     }
     catch (error) {
+      throw (this._handleError(error));
+    }
+  }
+
+  getMedias (memberType, identifier, options = {}) {
+    try {
+      Logger.info(LOG_PREFIX, `getMedias request for ${identifier}`, { memberType, identifier, options });
+      let { types, mediaTypes } = options;
+
+      if (types) {
+        types = types.map(t => C.EMAP[t]);
+      }
+
+      let mediaSessions = this._getMediasByMemberIdentifier(memberType, identifier);
+
+      if (types || mediaTypes) {
+        mediaSessions = mediaSessions.filter(ms => {
+          const msTypesMatch = !types || types.some(ms.type);
+          const msMTypesMatch = !mediaTypes
+            || !Object.keys(ms.mediaTypes).some(msk => {
+              if (mediaTypes[msk] && !ms.mediaTypes[msk]) {
+                return true;
+              }
+              return false;
+            });
+
+          return msTypesMatch && msMTypesMatch;
+        });
+
+        mediasSessions.forEach(ms => {
+          ms.medias = ms.medias.filter(({ mediaTypes: msMediaTypes }) => {
+            const msmtk = Object.keys(msMediaTypes);
+            return msMediaTypes[msmtk] === mediaTypes[msmt];
+          });
+        });
+      }
+
+      return mediaSessions;
+    } catch (error) {
       throw (this._handleError(error));
     }
   }

--- a/lib/mcs-core/lib/model/room.js
+++ b/lib/mcs-core/lib/model/room.js
@@ -53,6 +53,10 @@ module.exports = class Room {
     };
   }
 
+  getMediaInfos () {
+    return this.mediaSessions.map(ms => ms.getMediaInfo());
+  }
+
   getUser (id) {
     return this.users[id];
   }

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -273,7 +273,7 @@ module.exports = class User extends EventEmitter  {
     return userInfo;
   }
 
-  getUserMedias () {
+  getMediaInfos () {
     return Object.keys(this.mediaSessions).map(mk => this.mediaSessions[mk].getMediaInfo());
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -943,8 +943,8 @@
       }
     },
     "mcs-js": {
-      "version": "git+https://github.com/mconftec/mcs-js.git#06a1e274f9e4d4037cae51a16269edefc9138a3b",
-      "from": "git+https://github.com/mconftec/mcs-js.git#v0.0.8",
+      "version": "git+https://github.com/mconftec/mcs-js.git#81189f98422825ef9f352433b8df0f6850b4b35b",
+      "from": "git+https://github.com/mconftec/mcs-js.git#0.x-release",
       "requires": {
         "uuid": "3.3.2",
         "ws": "6.1.2"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "googleapis": "^43.0.0",
     "js-yaml": "3.13.1",
     "kurento-client": "git+https://github.com/Kurento/kurento-client-js.git#6.11.0",
-    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.8",
+    "mcs-js": "git+https://github.com/mconftec/mcs-js.git#0.x-release",
     "modesl": "1.2.0",
     "node-docker-api": "1.1.22",
     "pegjs": "0.8.0",


### PR DESCRIPTION
As defined in: https://github.com/mconf/mcs-js/commit/81189f98422825ef9f352433b8df0f6850b4b35b

`getMedias` accepts `memberType` (`room`|`user`|`mediaSession`|`medias`) and `identifier` (the unique internal ID for the identifier) as obligatory parameters and return an array of `mediaSession` or `media` info objects.
It has an optional parameter object (`options`) with two implemented parameters:
  - `types`: internal media types to filter in the return value (`[ RTP|WebRTC|RECORDING|URI ]`)
  - `mediaTypes`: a `mediaTypes` dictionary with the media types and media directions to filter in the return value.