### PR TITLE
Update video scale for content medias in RTP Sessions

### DIFF
--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -552,18 +552,18 @@ module.exports = class Kurento extends EventEmitter {
     hubPortMedia.subtitle = subtitle ? subtitle.slice(0,31) : "";
     hubPortMedia.enableSubtitle = enableSubtitle;
 
-    let mediaFilter = await this._createMediaFilter(mixer, hubPort,
+    let mediaFilter = await this._createHubPortMediaFilter(mixer, hubPort,
       hubPortMedia);
     this._mediaElements[mediaFilter.id] = mediaFilter;
 
-    let mediaFilterCaps = await this._createMediaFilterCaps(mixer, hubPort,
-      hubPortMedia);
+    let mediaFilterCaps = await this._createHubPortMediaFilterCaps(mixer,
+      hubPort, hubPortMedia);
     this._mediaElements[mediaFilterCaps.id] = mediaFilterCaps;
 
     return hubPortMedia;
   }
 
-  async _createMediaFilter(mixer, hubPort, hubPortMedia){
+  async _createHubPortMediaFilter(mixer, hubPort, hubPortMedia){
     let command = this._generateTextOverlayCommand(hubPortMedia.subtitle);
     let mediaFilter =
       await this._createGstreamerFilter(hubPort.pipeline, command);
@@ -579,7 +579,47 @@ module.exports = class Kurento extends EventEmitter {
     return mediaFilter;
   }
 
-  async _createMediaFilterCaps(mixer, hubPort, hubPortMedia){
+  /**
+   * Create Scale Media Filter.
+   * This fillter can be use to upscale/downscale video medias
+   * @param  {String}  roomId The id of the room where this is media filter
+   *                          is bound to
+   * @param  {int}  width  Width of the video
+   * @param  {int}  height Height of the video
+   * @return {Promise}
+   */
+  async createScaleMediaFilter (roomId, width, height) {
+    try {
+      let host = await this.balancer.getHost(C.MEDIA_PROFILE.MAIN);
+      await this._getMediaPipeline(host.id, roomId);
+      let pipeline = this._mediaPipelines[roomId][host.id];
+
+      let command = 'capsfilter caps="video/x-raw, width=' + width +
+        ', height=' + height + '"';
+
+      let mediaFilterElement =
+        await this._createGstreamerFilter(pipeline, command);
+      this._mediaPipelines[roomId][host.id].activeElements++;
+
+      mediaFilterElement.host = host;
+
+      this._mediaElements[mediaFilterElement.id] = mediaFilterElement;
+      Logger.info (LOG_PREFIX, 'Created a videoscale filter for roomId', roomId,
+        '. Scale resolution:', width, 'x', height);
+
+      let mediaFilter = new Media(roomId, null, null,
+        C.MEDIA_TYPE.VIDEO, this, mediaFilterElement.id, host);
+
+      mediaFilter.mediaTypes.video = 'sendrecv';
+      mediaFilter.mediaTypes.content = 'sendrecv';
+
+      return [mediaFilter];
+    } catch (error) {
+      throw (this._handleError(error));
+    }
+  }
+
+  async _createHubPortMediaFilterCaps(mixer, hubPort, hubPortMedia){
     let commandCaps =
       'capsfilter caps="video/x-raw, width=1280, height=720"';
     let mediaFilterCaps =

--- a/lib/mcs-core/lib/constants/constants.js
+++ b/lib/mcs-core/lib/constants/constants.js
@@ -30,6 +30,7 @@ exports.MEDIA_TYPE.URI = "PlayerEndpoint"
 exports.MEDIA_TYPE.RECORDING = "RecorderEndpoint"
 exports.MEDIA_TYPE.MCU = "MCU"
 exports.MEDIA_TYPE.HUBPORT = "HubPort"
+exports.MEDIA_TYPE.FILTER = "Filter"
 
 exports.MEDIA_PROFILE = {}
 exports.MEDIA_PROFILE.MAIN = 'main'
@@ -42,6 +43,9 @@ exports.CONNECTION_TYPE.VIDEO = 'VIDEO'
 exports.CONNECTION_TYPE.AUDIO = 'AUDIO'
 exports.CONNECTION_TYPE.CONTENT = 'CONTENT'
 exports.CONNECTION_TYPE.ALL = 'ALL'
+
+exports.FILTER_TYPE = {}
+exports.FILTER_TYPE.VIDEOSCALE = 'VIDEOSCALE'
 
 exports.NEGOTIATION_ROLE = {}
 exports.NEGOTIATION_ROLE.OFFERER = 'offerer';

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -12,6 +12,8 @@ const AdapterFactory = require('../adapters/adapter-factory');
 const StrategyManager = require('./strategy-manager.js');
 const MediaFactory = require('./media-factory.js');
 const { global: GLOBAL_MEDIA_THRESHOLD } = config.get('mediaThresholds');
+const DEFAULT_RTP_CONTENT_VIDEO_WIDTH = 1280;
+const DEFAULT_RTP_CONTENT_VIDEO_HEIGHT = 720;
 
 const LOG_PREFIX = "[mcs-controller]";
 
@@ -120,8 +122,11 @@ module.exports = class MediaController {
       } finally {
         //TODO: allow multiple MCU medias. We now use a single one.
         const defaultMediaSession = room.getDefaultMcuMediaSession();
-        if (defaultMediaSession) {
-          if (room.getNumberOfMcuUsers() < 1) {
+        const videoscaleFilterMediaSession =
+          room.getVideoscaleFilterMediaSession();
+
+        if (room.getNumberOfMcuUsers() < 1) {
+          if (defaultMediaSession) {
             Logger.info(LOG_PREFIX, 'Removing MCU session since',
               'there\'s no more MCU users in this room:', room.id,
               '. MCU Session:', defaultMediaSession.id);
@@ -134,6 +139,15 @@ module.exports = class MediaController {
             Logger.info(LOG_PREFIX, 'MCU Media Session not removed',
               'because there are active MCU Users.',
               'Number of MCU USers in this room',room.getNumberOfMcuUsers());
+          }
+
+          if (videoscaleFilterMediaSession) {
+            Logger.info(LOG_PREFIX, 'Removing videoscale session since',
+              'there\'s no more MCU users in this room:', room.id,
+              '. Session:', videoscaleFilterMediaSession.id);
+            await videoscaleFilterMediaSession.stop();
+
+            room.removeVideoscaleFilterMediaSession();
           }
         }
       }
@@ -993,8 +1007,28 @@ module.exports = class MediaController {
         return;
       }
 
+      let videoscaleFilterMediaSession = room.getVideoscaleFilterMediaSession();
+
       await Promise.all(contentMediaSessions.map(async (mediaSession) => {
-        await newContentMedia.connect(mediaSession, C.CONNECTION_TYPE.CONTENT);
+        if (mediaSession.type == C.MEDIA_TYPE.RTP) {
+          if (!videoscaleFilterMediaSession) {
+            videoscaleFilterMediaSession =
+              await room.createVideoscaleFilterMediaSession();
+
+            await room.processVideoscaleFilterMediaSession(
+              DEFAULT_RTP_CONTENT_VIDEO_WIDTH,
+              DEFAULT_RTP_CONTENT_VIDEO_HEIGHT
+            );
+          }
+
+          await newContentMedia.connect(videoscaleFilterMediaSession,
+            C.CONNECTION_TYPE.CONTENT);
+          await videoscaleFilterMediaSession.connect(mediaSession,
+            C.CONNECTION_TYPE.CONTENT);
+        } else {
+          await newContentMedia.connect(mediaSession,
+            C.CONNECTION_TYPE.CONTENT);
+        }
       }));
     } catch (error) {
       throw error;

--- a/lib/mcs-core/lib/media/media-factory.js
+++ b/lib/mcs-core/lib/media/media-factory.js
@@ -67,6 +67,10 @@ class MediaFactory extends EventEmitter {
         break;
       case C.MEDIA_TYPE.MCU:
         return this._createMCUSession(roomId, params);
+      case C.MEDIA_TYPE.FILTER:
+        mediaSession = this._createFilterMediaSession(roomId, userId, type,
+          params);
+        break;
       default:
         throw C.ERROR.MEDIA_INVALID_TYPE;
     }
@@ -125,6 +129,10 @@ class MediaFactory extends EventEmitter {
   _createRecordingMedia (recordingPath, type, roomId, userId, params) {
     return new RecordingMedia(roomId, userId, recordingPath, params);
   }
+
+  _createFilterMediaSession(roomId, userId, type, params) {
+    return new FilterMediaSession(roomId, userId, type, params);
+  }
 }
 
 const MF = new MediaFactory();
@@ -136,4 +144,4 @@ const RecordingSession = require('../model/recording-session.js');
 const SDPMedia = require('../model/sdp-media.js');
 const RecordingMedia = require('../model/recording-media.js');
 const MCUSession = require('../model/mcu-session');
-
+const FilterMediaSession = require('../model/filter-session');

--- a/lib/mcs-core/lib/model/filter-session.js
+++ b/lib/mcs-core/lib/model/filter-session.js
@@ -1,0 +1,48 @@
+'use strict'
+const C = require('../constants/constants');
+const MediaSession = require('./media-session');
+const Logger = require('../utils/logger');
+const LOG_PREFIX = '[mcs-filter-session]';
+
+/**
+ * @classdesc
+ * Class for handling Filter sessions in mcs-core.
+ */
+class FilterSession extends MediaSession {
+  constructor(roomId, userId, options) {
+    super(roomId, userId, C.MEDIA_TYPE.FILTER, options);
+  }
+
+  async process(connectionType, filterType, args) {
+    try {
+      if (connectionType != C.CONNECTION_TYPE.VIDEO) {
+        Logger.warn(LOG_PREFIX, 'Could not process the filter: connection',
+          'type [', connectionType, '] not supported');
+        return;
+      }
+
+      let videoAdapter = this._adapters.videoAdapter;
+
+      switch (filterType) {
+        case C.FILTER_TYPE.VIDEOSCALE:
+          if (!args) {
+            throw new Error('Invalid args, the object must contain width and',
+              'height properties');
+          }
+
+          Logger.info(LOG_PREFIX, 'Processing VIDEOSCALE filter', args);
+          this.medias = await videoAdapter.createScaleMediaFilter(this.roomId,
+            args.width, args.height);
+
+          this.mediaTypes.video = 'sendrecv';
+        break;
+        default:
+        break;
+      }
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+module.exports = FilterSession;

--- a/lib/mcs-core/lib/model/room.js
+++ b/lib/mcs-core/lib/model/room.js
@@ -32,6 +32,7 @@ module.exports = class Room {
     this._trackContentMediaDisconnection();
     this._trackConferenceMediaDisconnection();
     this._strategy = C.STRATEGIES.FREEWILL;
+    this._videoscaleFilterMediaSession = null;
   }
 
   set strategy (strategy) {
@@ -164,6 +165,14 @@ module.exports = class Room {
 
   getContentFloorMedia() {
     return this._contentFloor ? this._contentFloor : null;
+  }
+
+  getVideoscaleFilterMediaSession () {
+    return this._videoscaleFilterMediaSession;
+  }
+
+  setVideoscaleFilterMediaSession (videoScaleFilterMediaSession) {
+    return this._videoscaleFilterMediaSession = videoScaleFilterMediaSession;
   }
 
   _setPreviousConferenceFloor () {
@@ -350,11 +359,60 @@ module.exports = class Room {
   }
 
   /**
+   * Create a new videoscale filter session for this room.
+   * This videoscale is needed to limit content video resolution to HD720p
+   * This limit is intended to be applied to all RTP users, once in most cases
+   * endpoint don't support video streams above HD720p.
+   * @return {Object}
+   */
+  async createVideoscaleFilterMediaSession () {
+    try {
+      let videoscaleFilterMediaSession = this.getVideoscaleFilterMediaSession();
+      if (videoscaleFilterMediaSession) {
+        Logger.info('[room] Videoscale filter media ',
+          'already created for this room:', this.id);
+        return videoscaleFilterMediaSession;
+      }
+
+      videoscaleFilterMediaSession = MediaFactory.createMediaSession(null,
+        C.MEDIA_TYPE.FILTER, this.id, null, null);
+      this.setVideoscaleFilterMediaSession(videoscaleFilterMediaSession);
+      videoscaleFilterMediaSession.mediaTypes.content = 'sendrecv';
+      return videoscaleFilterMediaSession;
+    } catch (error) {
+      throw (this._handleError(error));
+    }
+  }
+
+  async processVideoscaleFilterMediaSession(width, height) {
+    try {
+      let videoscaleFilterMediaSession = this.getVideoscaleFilterMediaSession();
+      await videoscaleFilterMediaSession.process(C.CONNECTION_TYPE.VIDEO,
+        C.FILTER_TYPE.VIDEOSCALE, {width: width, height: height});
+    } catch (error) {
+      throw (this._handleError(error));
+    }
+  }
+
+  /**
    * Remove default MCU Media session
    */
   removeDefaultMcuMediaSession () {
     try {
       return this.removeMediaSessionByName(DEFAULT_MEDIA_SESSION_NAME);
+    } catch (error) {
+      throw (this._handleError(error));
+    }
+  }
+
+  /**
+   * Remove videoscale filter media session of this room.
+   */
+  removeVideoscaleFilterMediaSession () {
+    try {
+      if (this.videocaleFilterMediaSession) {
+        this.removeMediaSession(videocaleFilterMediaSession.id);
+      }
     } catch (error) {
       throw (this._handleError(error));
     }


### PR DESCRIPTION
Content video in RTP Sessions are now limited to output 1280x720 pixels
Web/WEBRTC users's still send/receive your content stream without video scaling
A small refactoring in kurento adapter, changing mediaFilter's name to hubPortMediafilter, once these functions are specific for hubports