### PR TITLE
Backport #169 and adjust external video sources indexing

### DIFF
--- a/lib/video/VideoManager.js
+++ b/lib/video/VideoManager.js
@@ -176,7 +176,8 @@ module.exports = class VideoManager extends BaseManager {
       const { stream, userId } = payload;
       if (userId.match(/^v_*/ig)) {
         Logger.info(this._logPrefix, "Tracking external video source", payload);
-        Video.setSource(userId, stream.replace(/\|SIP/ig, ''));
+        const normalizedStreamName = stream.replace(/\|SIP/ig, '');
+        Video.setSource(stream, normalizedStreamName);
       }
     });
   }

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -255,7 +255,7 @@ module.exports = class Video extends BaseProvider {
     return new Promise(async (resolve, reject) => {
       try {
         const cameraCodec = DEFAULT_MEDIA_SPECS.codec_video_main;
-        const recordingName = this._cameraProfile + '-' + this.id;
+        const recordingName = `${this._cameraProfile}-${this.bbbUserId}`;
         const recordingProfile = (cameraCodec === 'VP8' || cameraCodec === 'ANY')
           ? C.RECORDING_PROFILE_WEBM
           : C.RECORDING_PROFILE_MKV;


### PR DESCRIPTION
Changes:
  - Backport #169
  - [video] Change external video source indexing to be based on the raw stream name. This follows some changes made to the video-provider in order to support multiple cameras.