### PR TITLE
v2.4.9

### DIFF
--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -306,7 +306,7 @@ module.exports = class SdpWrapper {
   }
 
   static isContentSlides (mediaLine) {
-    const hasContentSlides = !!mediaLine.content && mediaLine.content === 'slides';
+    const hasContentSlides = !!mediaLine.content && mediaLine.content.includes('slides');
     return mediaLine.type === "video" && hasContentSlides;
   }
 

--- a/lib/video/VideoManager.js
+++ b/lib/video/VideoManager.js
@@ -187,6 +187,7 @@ module.exports = class VideoManager extends BaseManager {
         Logger.info(this._logPrefix, "Tracking external video source", payload);
         const normalizedStreamName = stream.replace(/\|SIP/ig, '');
         Video.setSource(stream, normalizedStreamName);
+        Video.setSource(userId, normalizedStreamName);
       }
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.7",
+  "version": "2.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.7",
+  "version": "2.4.9",
   "private": true,
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
Patch release v2.4.9.

__CHANGELOG__:
- [mcs-core/kurento] MEDIA_STATE event for RTCP isn't adding the state to `details` #197
- [video] External video indexing is broken after the stream ID format was changed #198 
- [mcs-core/sdp] Fix `content:slides` parsing failing in some cases 14d8e2c