### PR TITLE
v2.4.11

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -176,7 +176,7 @@ conference-media-specs:
     tias_content: "1500000"
     as_content: "1500"
   OPUS:
-    useinbandfec: "0"
+    useinbandfec: "1"
     maxaveragebitrate: "30000"
     maxplaybackrate: "48000"
     ptime: "20"

--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -328,6 +328,7 @@ module.exports = class Audio extends BaseProvider {
             descriptor: answer,
             name: `PROXY_${calleeName}|subscribe`,
             ignoreThresholds: true,
+            hackForceActiveDirection: true,
           }
 
           const { mediaId: proxyId, answer: proxyAnswer } = await this.mcs.subscribe(

--- a/lib/mcs-core/lib/adapters/freeswitch/esl-wrapper.js
+++ b/lib/mcs-core/lib/adapters/freeswitch/esl-wrapper.js
@@ -3,9 +3,11 @@ const C = require('../../constants/constants.js');
 const { Connection } = require('modesl');
 const Logger = require('../../utils/logger');
 const config = require('config');
-const ESL_IP = config.get('freeswitch').esl_ip;
-const ESL_PORT = config.get('freeswitch').esl_port;
-const ESL_PASS = "ClueCon";
+const ESL_IP = config.get('freeswitch.esl_ip');
+const ESL_PORT = config.get('freeswitch.esl_port');
+const ESL_PASS = config.has('freeswitch.esl_password')
+  ? config.get('freeswitch.esl_password')
+  : 'ClueCon';
 const LOG_PREFIX = "[mcs-freeswitch-esl-wrapper]";
 const { handleError } = require('../../utils/util');
 const RECONNECTION_TIMER = 5000;
@@ -132,8 +134,8 @@ class EslWrapper extends EventEmitter {
 
     this._client.auth((error) => {
       if (error) {
+        Logger.error(LOG_PREFIX, `FreeSWITCH ESL connection authentication error`);
         this.error = this._normalizeError(C.ERROR.MEDIA_ESL_AUTHENTICATION_ERROR, error.message)
-        throw (this.error);
       }
     });
   }
@@ -194,6 +196,7 @@ class EslWrapper extends EventEmitter {
 
   _onDisconnection () {
     if (this._reconnectionRoutine == null) {
+      Logger.error(LOG_PREFIX, `FreeSWITCH ESL connection dropped unexpectedly`);
       this._reconnectionRoutine = setInterval(async () => {
         try {
           this.stop();

--- a/lib/mcs-core/lib/adapters/freeswitch/esl-wrapper.js
+++ b/lib/mcs-core/lib/adapters/freeswitch/esl-wrapper.js
@@ -8,6 +8,7 @@ const ESL_PORT = config.get('freeswitch').esl_port;
 const ESL_PASS = "ClueCon";
 const LOG_PREFIX = "[mcs-freeswitch-esl-wrapper]";
 const { handleError } = require('../../utils/util');
+const RECONNECTION_TIMER = 5000;
 
 const ESL_MESSAGE = {
   AUTH: "auth",
@@ -28,7 +29,9 @@ const ESL_EVENTS = {
   CUSTOM: "CUSTOM",
   CHANNEL_ANSWER: "CHANNEL_ANSWER",
   CHANNEL_HANGUP_COMPLETE: "CHANNEL_HANGUP_COMPLETE",
-  PRESENCE_IN: "PRESENCE_IN"
+  PRESENCE_IN: "PRESENCE_IN",
+  END: "esl::end",
+  DISCONNECT_NOTICE: "esl::events::disconnect::notice",
 };
 
 const ESL_EVENT = {
@@ -47,8 +50,8 @@ const ESL_EVENT = {
   TALKING: 'Talking',
   VOLUME_LEVEL: "Volume-Level",
   CONFERENCE_NAME: "Conference-Name",
-  OLD_ID: "Old-ID",
-  NEW_ID: "New-ID",
+  OLD_ID: 'Old-ID',
+  NEW_ID: 'New-ID',
 };
 
 const ESL_SUBCLASSES = {
@@ -119,52 +122,45 @@ class EslWrapper extends EventEmitter {
     this._params = params;
   }
 
+  _connect () {
+    this._client = new Connection(
+      this._clientOptions.host,
+      this._clientOptions.port,
+      this._clientOptions.auth,
+      this._onConnected.bind(this)
+    );
+
+    this._client.auth((error) => {
+      if (error) {
+        this.error = this._normalizeError(C.ERROR.MEDIA_ESL_AUTHENTICATION_ERROR, error.message)
+        throw (this.error);
+      }
+    });
+  }
+
+  _monitorESLClientConnectionErrors () {
+    this._client.on('error', (error) => {
+      if (error) {
+        Logger.error(LOG_PREFIX, `FreeSWITCH ESL connection received error ${error.code}`,
+          { error });
+        this.error = this._normalizeError(C.ERROR.MEDIA_ESL_CONNECTION_ERROR, error.message);
+        this._onDisconnection();
+      }
+    });
+  }
+
   /**
    * Start ESL, connecting to FreeSWITCH
    * @return {Promise} A Promise for the starting process
    */
   start () {
     try {
-      this._client = new Connection(
-        this._clientOptions.host,
-        this._clientOptions.port,
-        this._clientOptions.auth,
-        this._onConnected.bind(this)
-      );
-
-      this._client.auth((error) => {
-        if (error) {
-          this.error = this._handleError(C.ERROR.MEDIA_ESL_AUTHENTICATION_ERROR, error.message)
-          throw (error);
-        }
-      });
-
-      this._client.on('error', (error) => {
-        if(error) {
-          switch(error.code) {
-            case 'ECONNREFUSED':
-              Logger.error(LOG_PREFIX,'Could not connect to ' +
-                'freeswitch host - connection refused.');
-              this.error = this._handleError(C.ERROR.MEDIA_ESL_CONNECTION_ERROR, error.message);
-              throw (error);
-            case 'ECONNRESET':
-              Logger.error(LOG_PREFIX,'Connection to host reseted.');
-              this.error = this._handleError(C.ERROR.MEDIA_ESL_CONNECTION_ERROR, error.message);
-              throw (error);
-            case 'EHOSTUNREACH':
-              Logger.error(LOG_PREFIX,'Could not connect to ' +
-              ' freeswitch host - host unreach.');
-              this.error = this._handleError(C.ERROR.MEDIA_ESL_CONNECTION_ERROR, error.message);
-              throw (error);
-            default:
-              this.error = this._handleError(C.ERROR.MEDIA_ESL_CONNECTION_ERROR, error.message);
-              throw (error);
-          }
-        }
-      });
-    } catch (error) {
-      Logger.error(LOG_PREFIX,error);
-      throw (this._handleError(error));
+      this._connect();
+      this._monitorESLClientConnectionErrors();
+      } catch (error) {
+        Logger.error(LOG_PREFIX, `Error when starting ESL interface`,
+          { error });
+      throw (this._normalizeError(error));
     }
   }
 
@@ -184,15 +180,41 @@ class EslWrapper extends EventEmitter {
   }
 
   _onConnected () {
+    Logger.info(LOG_PREFIX, `Connected to FreeSWITCH ESL`);
+
+    if (this._reconnectionRoutine) {
+      clearInterval(this._reconnectionRoutine);
+      this._reconnectionRoutine = null;
+    }
+
     this._client.subscribe([
       'all'
     ], this._onSubscribed.bind(this));
+  }
+
+  _onDisconnection () {
+    if (this._reconnectionRoutine == null) {
+      this._reconnectionRoutine = setInterval(async () => {
+        try {
+          this.stop();
+          this._connect();
+          this._monitorESLClientConnectionErrors();
+        } catch (error) {
+          Logger.warn(LOG_PREFIX, `Failed to reconnect to ESL, try again in ${RECONNECTION_TIMER}`,
+            { error });
+          this.stop();
+        }
+      }, RECONNECTION_TIMER);
+    }
   }
 
   _onSubscribed () {
     this._client.on('esl::event::'+ESL_EVENTS.CUSTOM+'::*', this._onCustomEvent.bind(this));
     this._client.on('esl::event::'+ESL_EVENTS.CHANNEL_ANSWER+'::*', this._onChannelAnswer.bind(this));
     this._client.on('esl::event::'+ESL_EVENTS.CHANNEL_HANGUP_COMPLETE+'::*', this._onChannelHangup.bind(this));
+    this._client.on(ESL_EVENTS.DISCONNECT_NOTICE, this._onDisconnection.bind(this));
+    this._client.on(ESL_EVENTS.END, this._onDisconnection.bind(this));
+
     this.connected = true;
   }
 
@@ -207,7 +229,7 @@ class EslWrapper extends EventEmitter {
         const body = res.getBody();
         Logger.debug(LOG_PREFIX, `Command response for "${command}" is: ${JSON.stringify(body)}`);
         if (this._hasError(body) && !body.includes('no reply')) {
-          return reject(this._handleError(C.ERROR.MEDIA_ESL_COMMAND_ERROR,body));
+          return reject(this._normalizeError(C.ERROR.MEDIA_ESL_COMMAND_ERROR, body));
         }
         return resolve();
       });
@@ -231,7 +253,7 @@ class EslWrapper extends EventEmitter {
     } catch (error) {
       Logger.error(LOG_PREFIX, `Error when executing setVolume command ${error.message}`,
         { conferenceId, memberId, volume, error });
-      throw (this._handleError(error));
+      throw (this._normalizeError(error));
     }
   }
 
@@ -251,7 +273,7 @@ class EslWrapper extends EventEmitter {
     } catch (error) {
       Logger.error(LOG_PREFIX, `Error when executing mute command ${error.message}`,
         { conferenceId, memberId, error });
-      throw (this._handleError(error));
+      throw (this._normalizeError(error));
     }
   }
 
@@ -271,7 +293,7 @@ class EslWrapper extends EventEmitter {
     } catch (error) {
       Logger.error(LOG_PREFIX, `Error when executing unmute command ${error.message}`,
         { conferenceId, memberId, error });
-      throw (this._handleError(error));
+      throw (this._normalizeError(error));
     }
   }
 
@@ -284,7 +306,7 @@ class EslWrapper extends EventEmitter {
     } catch (error) {
       Logger.error(LOG_PREFIX, `Error when executing dtmf command ${error.message}`,
         { channelId, tone, error });
-      throw (this._handleError(error));
+      throw (this._normalizeError(error));
     }
   }
 
@@ -360,7 +382,7 @@ class EslWrapper extends EventEmitter {
     return body.startsWith("-ERR");
   }
 
-  _handleError (error,details) {
+  _normalizeError (error, details) {
     if (details) {
       error.details = details;
     }

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -60,6 +60,10 @@ module.exports = class SDPSession extends MediaSession {
 
       this._remoteDescriptor = new SdpWrapper(remoteDescriptor, this.mediaSpecs, this._mediaProfile);
 
+      if (this._options.hackForceActiveDirection) {
+        this._remoteDescriptor.forceActiveDirection();
+      }
+
       if (this.negotiationRole === C.NEGOTIATION_ROLE.OFFERER) {
         this.mediaSpecs = SdpWrapper.updateSpecWithChosenCodecs(this.remoteDescriptor);
       }

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -938,4 +938,11 @@ module.exports = class SdpWrapper {
     updatedWrapper.mediaSpecs.codec_audio = codec_audio? codec_audio : updatedWrapper.mediaSpecs.codec_audio;
     return updatedWrapper.mediaSpecs;
   }
+
+  forceActiveDirection () {
+    this._plainSdp = this._plainSdp.replace(/(m=.*\r\n)/g, (str, match)  => {
+      return match + 'a=direction:active\r\n';
+    });
+    this._jsonSdp = transform.parse(this._plainSdp);
+  }
 };

--- a/lib/video/VideoManager.js
+++ b/lib/video/VideoManager.js
@@ -187,6 +187,7 @@ module.exports = class VideoManager extends BaseManager {
         Logger.info(this._logPrefix, "Tracking external video source", payload);
         const normalizedStreamName = stream.replace(/\|SIP/ig, '');
         Video.setSource(stream, normalizedStreamName);
+        Video.setSource(userId, normalizedStreamName);
       }
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,9 +1014,9 @@
       }
     },
     "modesl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/modesl/-/modesl-1.2.0.tgz",
-      "integrity": "sha1-j+BXr/Dfw4XTNd6vfwyWpqs+MpA=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/modesl/-/modesl-1.2.1.tgz",
+      "integrity": "sha512-B4ROC+xyZ9guF91dYSMQFLccHogjbMOA5Z3z17DLX1i2Dx8H+fIrTfoc1LWLAltqGf0WlnXZoosbC8BEPYY31w==",
       "requires": {
         "eventemitter2": "^4.1",
         "uuid": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.7",
+  "version": "2.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "js-yaml": "3.13.1",
     "kurento-client": "git+https://github.com/Kurento/kurento-client-js.git#6.12.0",
     "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.9",
-    "modesl": "1.2.0",
+    "modesl": "1.2.1",
     "node-docker-api": "1.1.22",
     "pegjs": "0.8.0",
     "readable-id": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "private": true,
   "scripts": {
     "start": "node server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.7",
+  "version": "2.4.9",
   "private": true,
   "scripts": {
     "start": "node server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "private": true,
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
Patch release v2.4.11.

__CHANGELOG__:
  - [mcs-core] Add `hackForceActiveDirection` optional parameter for SDP sessions (triggers COMEDIA in the KMS adapter) 4fc148d 
    * Also use it in SFU#audio for the GLOBAL_AUDIO bridge to avoid MEDIA_TIMEOUTs due to RTCP not being able to be delivered from KMS to FreeSWITCH. The latter adopts an autonat discovery based on WS which makes it listen for RTCP packets on a different address if the server is behind NAT and there's a loopback interface redirecting internal packets that go through the main network interface.
  - [mcs-core] Add some sort of reconnection procedure to new ESL wrapper #92
  - Bump modesl to v1.2.1 61613fb
  - Set default OPUS useinbandfec to 1 0571144
  - Add optional ESL password config 4ab0705 