### PR TITLE
Remove built-in log rotation

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -25,7 +25,6 @@ freeswitch:
 log:
     level: LOG_LEVEL
     filename: LOG_FILENAME
-    maxFiles: LOG_MAX_FILES
 
 bbb-stream:
   image_name: STREAM_IMAGE_NAME

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -71,12 +71,9 @@ freeswitch:
     local:
     private:
     public:
-# maxFiles: number of old log files to keep track of. Logs are rotated daily,
-# so maxFiles = amount of days to keep of logs
 log:
   filename: /var/log/bbb-webrtc-sfu/bbb-webrtc-sfu.log
   level: verbose
-  maxFiles: 14
 bbb-stream:
   image_name: bbb-stream
   container_type: docker

--- a/lib/mcs-core/lib/utils/logger.js
+++ b/lib/mcs-core/lib/utils/logger.js
@@ -3,12 +3,9 @@
 const Winston = require('winston');
 const Logger = new Winston.Logger();
 const config = require('config');
-const path = require('path');
-Winston.transports.DailyRotateFile = require('winston-daily-rotate-file');
 
 const LOG_CONFIG = config.get('log') || {};
-// 14 files is the default maxFiles value for deleting old logs
-const { level, filename, maxFiles = 14 } = LOG_CONFIG;
+const { level, filename } = LOG_CONFIG;
 
 Logger.configure({
   levels: { error: 0, warn: 1, info: 2, verbose: 3, debug: 4, trace: 5 },
@@ -35,14 +32,12 @@ Logger.add(Winston.transports.Console, {
 
 
 if (filename) {
-  Logger.add(Winston.transports.DailyRotateFile, {
+  Logger.add(Winston.transports.File, {
     filename,
     prettyPrint: false,
-    datePattern: '.yyyy-MM-dd',
     prepend: false,
     stringify: (obj) => JSON.stringify(obj), // single lines
     level,
-    maxDays: maxFiles,
   });
 }
 

--- a/lib/utils/Logger.js
+++ b/lib/utils/Logger.js
@@ -3,11 +3,9 @@
 const Winston = require('winston');
 const Logger = new Winston.Logger();
 const config = require('config');
-Winston.transports.DailyRotateFile = require('winston-daily-rotate-file');
 
 const LOG_CONFIG = config.get('log') || {};
-// 14 files is the default maxFiles value for deleting old logs
-const { level, filename, maxFiles = 14 } = LOG_CONFIG;
+const { level, filename } = LOG_CONFIG;
 
 Logger.configure({
   levels: { error: 0, warn: 1, info: 2, verbose: 3, debug: 4, trace: 5 },
@@ -34,14 +32,12 @@ Logger.add(Winston.transports.Console, {
 
 
 if (filename) {
-  Logger.add(Winston.transports.DailyRotateFile, {
+  Logger.add(Winston.transports.File, {
     filename,
     prettyPrint: false,
-    datePattern: '.yyyy-MM-dd',
     prepend: false,
     stringify: (obj) => JSON.stringify(obj), // single lines
     level,
-    maxDays: maxFiles,
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,21 +1003,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
-      }
-    },
     "modesl": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/modesl/-/modesl-1.2.1.tgz",
@@ -1579,14 +1564,6 @@
           "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         }
-      }
-    },
-    "winston-daily-rotate-file": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-1.7.2.tgz",
-      "integrity": "sha1-ZQK/opeCT9mC2l5WR8dThXjS+aA=",
-      "requires": {
-        "mkdirp": "0.5.1"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "sdp-transform": "2.13.0",
     "sip.js": "git+https://github.com/mconf/sip.js.git#v0.7.5.10",
     "winston": "2.4.2",
-    "winston-daily-rotate-file": "1.7.2",
     "ws": "3.3.3"
   },
   "optionalDependencies": {}


### PR DESCRIPTION
- Removes the built-in log rotation (in favour of external methods ie logrotate + cron).
- Removes the `winston-daily-rotate-file` dependecy.

Ref #27.