### PR TITLE
Fix listen only not flowing timeout handling

### DIFF
--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -22,8 +22,6 @@ module.exports = class Audio extends BaseProvider {
     this.sourceAudioStarted = false;
     this.sourceAudioStatus = C.MEDIA_STOPPED;
     this.audioEndpoints = {};
-    this.role;
-    this.webRtcEndpoint = null;
     this.userId;
     this._mediaFlowingTimeouts = {};
     this.connectedUsers = {};
@@ -225,6 +223,11 @@ module.exports = class Audio extends BaseProvider {
   _onListenOnlySubscriberMediaNotFlowing (connectionId) {
     Logger.warn(LOG_PREFIX, `Listen only session WebRTC media is NOT_FLOWING`,
       this._getFullLogMetadata(connectionId));
+  }
+
+  _onListenOnlySubscriberMediaNotFlowingTimeout (connectionId) {
+    Logger.error(LOG_PREFIX, `Listen only session WebRTC media NOT_FLOWING timeout reached`,
+      this._getFullLogMetadata(connectionId));
     this.bbbGW.publish(JSON.stringify({
         connectionId: connectionId,
         id: "webRTCAudioError",
@@ -305,10 +308,6 @@ module.exports = class Audio extends BaseProvider {
         break;
 
       case "MediaFlowOutStateChange":
-        Logger.debug(LOG_PREFIX, `WebRTC listen only session ${mediaId} received MediaFlowOut`,
-          { ...logMetadata, state });
-        break;
-
       case "MediaFlowInStateChange":
         Logger.debug(LOG_PREFIX, `WebRTC listen only session ${mediaId} received MediaFlowIn`,
           { ...logMetadata, state });
@@ -316,8 +315,10 @@ module.exports = class Audio extends BaseProvider {
         if (details === 'FLOWING') {
           this._onListenOnlySubscriberMediaFlowing(connectionId);
         } else {
+          this._onListenOnlySubscriberMediaNotFlowing(connectionId);
           this.setMediaFlowingTimeout(connectionId);
         }
+
         break;
 
       case C.MEDIA_SERVER_OFFLINE:
@@ -333,10 +334,10 @@ module.exports = class Audio extends BaseProvider {
 
   setMediaFlowingTimeout(connectionId) {
     if (!this._mediaFlowingTimeouts[connectionId]) {
-      Logger.debug(LOG_PREFIX, `setMediaFlowingTimeout for listener ${connectionId}`,
-        this._getFullLogMetadata(connectionId));
+      Logger.warn(LOG_PREFIX, `Listen only NOT_FLOWING timeout set`,
+        { ...this._getFullLogMetadata(connectionId), mediaFlowTimeoutDuration });
       this._mediaFlowingTimeouts[connectionId] = setTimeout(() => {
-        this._onListenOnlySubscriberMediaFlowing(connectionId);
+        this._onListenOnlySubscriberMediaNotFlowingTimeout(connectionId);
       }, mediaFlowTimeoutDuration);
     }
   }


### PR DESCRIPTION
During the stop procedure sanitizing and log refactor in the audio provider I messed up with the notFlowing/flowing handlers and mixed them up.