### PR TITLE
[audio] Clear mediaFlowing/State timeouts on stop

### DIFF
--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -608,6 +608,8 @@ module.exports = class Audio extends BaseProvider {
 
     delete this.candidatesQueue[connectionId];
     delete this.audioEndpoints[connectionId];
+    this.clearMediaFlowingTimeout(connectionId);
+    this.clearMediaStateTimeout(connectionId);
   }
 
   async stop () {


### PR DESCRIPTION
This should avoid a race condition. When a session was stopped before the media trigger cleared the timeouts, they would cause a leak and/or incorrectly trigger a trailing timeout on a probable successful re-connection.