### PR TITLE
Screenshare with audio, ... (replaces #251)

### DIFF
--- a/lib/base/MCSAPIWrapper.js
+++ b/lib/base/MCSAPIWrapper.js
@@ -269,6 +269,16 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
     }
   }
 
+  async getMedias (memberType, identifier, options = {}) {
+    try {
+      const mediaInfo = await this._mcs.getMedias(memberType, identifier, options);
+      return mediaInfo;
+    }
+    catch (error) {
+      throw (this._handleError(error, 'getMedias', { memberType, identifier, options }));
+    }
+  }
+
   setStrategy (strategy) {
     // TODO
   }

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -123,6 +123,7 @@ const config = require('config');
         TIMESTAMP: "timestamp",
         VIDEO_WIDTH: "vidWidth",
         VIDEO_HEIGHT: "vidHeight",
+        HASAUDIO: "hasAudio",
 
         // Audio
         NAME: "name",

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -123,7 +123,7 @@ const config = require('config');
         TIMESTAMP: "timestamp",
         VIDEO_WIDTH: "vidWidth",
         VIDEO_HEIGHT: "vidHeight",
-        HASAUDIO: "hasAudio",
+        HAS_AUDIO: "hasAudio",
 
         // Audio
         NAME: "name",

--- a/lib/bbb/messages/Messaging.js
+++ b/lib/bbb/messages/Messaging.js
@@ -70,8 +70,8 @@ Messaging.prototype.generateDeskShareRTMPBroadcastStoppedEvent =
 }
 
 Messaging.prototype.generateScreenshareRTMPBroadcastStartedEvent2x =
-  function(conferenceName, screenshareConf, streamUrl, vw, vh, timestamp) {
-  let stadrbem = new ScreenshareRTMPBroadcastStartedEventMessage2x(conferenceName, screenshareConf, streamUrl, vw, vh, timestamp);
+  function(conferenceName, screenshareConf, streamUrl, vw, vh, timestamp, hasAudio) {
+  let stadrbem = new ScreenshareRTMPBroadcastStartedEventMessage2x(conferenceName, screenshareConf, streamUrl, vw, vh, timestamp, hasAudio);
   return stadrbem.toJson();
 }
 

--- a/lib/bbb/messages/screenshare/ScreenshareRTMPBroadcastStartedEventMessage2x.js
+++ b/lib/bbb/messages/screenshare/ScreenshareRTMPBroadcastStartedEventMessage2x.js
@@ -18,7 +18,10 @@ module.exports = function (C) {
     this.core.body[C.VIDEO_WIDTH] = vw;
     this.core.body[C.VIDEO_HEIGHT] = vh;
     this.core.body[C.TIMESTAMP] = timestamp;
-    this.core.body[C.HAS_AUDIO] = hasAudio;
+    // Ensure backwards compatibility
+    if (typeof hasAudio !== 'undefined') {
+      this.core.body[C.HAS_AUDIO] = hasAudio;
+    }
   };
 
   inherits(ScreenshareRTMPBroadcastStartedEventMessage2x, OutMessage2x);

--- a/lib/bbb/messages/screenshare/ScreenshareRTMPBroadcastStartedEventMessage2x.js
+++ b/lib/bbb/messages/screenshare/ScreenshareRTMPBroadcastStartedEventMessage2x.js
@@ -1,5 +1,5 @@
 /*
- * 
+ *
  */
 
 var inherits = require('inherits');
@@ -13,12 +13,12 @@ module.exports = function (C) {
 
     this.core.body = {};
     this.core.body[C.CONFERENCE_NAME] = conferenceName;
-    this.core.body[C.SCREENSHARE_CONF] = screenshareConf; 
+    this.core.body[C.SCREENSHARE_CONF] = screenshareConf;
     this.core.body[C.STREAM_URL] = streamUrl;
     this.core.body[C.VIDEO_WIDTH] = vw;
     this.core.body[C.VIDEO_HEIGHT] = vh;
     this.core.body[C.TIMESTAMP] = timestamp;
-    this.core.body[C.HASAUDIO] = hasAudio;
+    this.core.body[C.HAS_AUDIO] = hasAudio;
   };
 
   inherits(ScreenshareRTMPBroadcastStartedEventMessage2x, OutMessage2x);

--- a/lib/bbb/messages/screenshare/ScreenshareRTMPBroadcastStartedEventMessage2x.js
+++ b/lib/bbb/messages/screenshare/ScreenshareRTMPBroadcastStartedEventMessage2x.js
@@ -7,7 +7,7 @@ var OutMessage2x = require('../OutMessage2x');
 
 module.exports = function (C) {
   function ScreenshareRTMPBroadcastStartedEventMessage2x (conferenceName, screenshareConf,
-      streamUrl, vw, vh, timestamp) {
+      streamUrl, vw, vh, timestamp, hasAudio) {
     ScreenshareRTMPBroadcastStartedEventMessage2x.super_.call(this, C.SCREENSHARE_RTMP_BROADCAST_STARTED_2x,
         {voiceConf: conferenceName}, {voiceConf: conferenceName});
 
@@ -18,6 +18,7 @@ module.exports = function (C) {
     this.core.body[C.VIDEO_WIDTH] = vw;
     this.core.body[C.VIDEO_HEIGHT] = vh;
     this.core.body[C.TIMESTAMP] = timestamp;
+    this.core.body[C.HASAUDIO] = hasAudio;
   };
 
   inherits(ScreenshareRTMPBroadcastStartedEventMessage2x, OutMessage2x);

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -487,26 +487,35 @@ module.exports = class SDPSession extends MediaSession {
   }
 
   addIceCandidate (candidate) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        this.medias.forEach(m => {
-          if (m.type === C.MEDIA_TYPE.WEBRTC) {
-            m.addIceCandidate(candidate).catch(error => {
-              Logger.warn(LOG_PREFIX, `Failed to add ICE candidate`, {
-                mediaSessionId: this.id,
-                mediaId: m.id,
-                candidate,
-                error: this._handleError(error)
-              });
-            });
-          };
+    const _add = (targetMedia, candidate) => {
+      if (targetMedia.type === C.MEDIA_TYPE.WEBRTC) {
+        return targetMedia.addIceCandidate(candidate).catch(error => {
+          Logger.warn(LOG_PREFIX, `Failed to add ICE candidate`, {
+            mediaSessionId: this.id,
+            mediaId: targetMedia.id,
+            candidate,
+            error: this._handleError(error)
+          });
+    
+          throw error;
         });
-
-        return resolve();
-      } catch (error) {
-        return reject(this._handleError(error));
-      }
-    });
+      };
+    };
+    if (this.medias.length === 1) {
+      return _add(this.medias[0], candidate);
+    }
+    
+    const { sdpMLineIndex, sdpMid } = candidate;
+    if (sdpMLineIndex && this.medias[sdpMLineIndex]) {
+      return _add(this.medias[sdpMLineIndex], candidate);
+    } else if (sdpMid && this.medias[sdpMid]) {
+      return _add(this.medias[sdpMid], candidate);
+    } else {
+      throw this._handleError({
+        ...C.ERROR.ICE_CANDIDATE_FAILED,
+        details: `Invalid or not found media index`,
+      });
+    }    
   }
 
   getAnswer () {

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -507,6 +507,15 @@ module.exports = class SdpWrapper {
 
     let res = transform.parse(descriptor);
     let descriptorsList = []
+
+    // Short-cut: one audio, one video ML => single descriptor, no splitting
+    if (res.media.length === 2) {
+      if (res.media.find(media => media.type === 'audio')
+        && res.media.find(media => media.type === 'video')) {
+        return [descriptor];
+      }
+    }
+
     res.media.forEach(media => {
       const stringifiedPartialSDP = SdpWrapper.reassembleSDPFromMediaLines(res, [media]);
       if (stringifiedPartialSDP && stringifiedPartialSDP !== '') {

--- a/lib/screenshare/ScreenshareManager.js
+++ b/lib/screenshare/ScreenshareManager.js
@@ -93,7 +93,7 @@ module.exports = class ScreenshareManager extends BaseManager {
       sdpOffer,
       callerName: userId,
       userName,
-      vh, vw,
+      vh, vw, hasAudio,
     } = message;
 
     let iceQueue, session;
@@ -109,7 +109,8 @@ module.exports = class ScreenshareManager extends BaseManager {
         connectionId,
         vh, vw,
         internalMeetingId,
-        this.mcs
+        this.mcs,
+        hasAudio,
       );
       this._sessions[voiceBridge] = session;
       this._meetings[internalMeetingId] = voiceBridge;

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -676,7 +676,7 @@ module.exports = class Screenshare extends BaseProvider {
     });
   }
 
-  async _startRtmpBroadcast (meetingId, output) {
+  _startRtmpBroadcast (meetingId, output) {
     // If output is defined, we're using a RTMP url for the flash bridge
     // Else just pass the WebRTC stream name
     if (output) {

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -675,7 +675,7 @@ module.exports = class Screenshare extends BaseProvider {
     });
   }
 
-  _startRtmpBroadcast (meetingId, output) {
+  async _startRtmpBroadcast (meetingId, output) {
     // If output is defined, we're using a RTMP url for the flash bridge
     // Else just pass the WebRTC stream name
     if (output) {
@@ -685,8 +685,16 @@ module.exports = class Screenshare extends BaseProvider {
     }
 
     const timestamp = Math.floor(new Date());
+    this.presenterHasAudio = false;
+    // Check if screenshare has audio to inform other participants they have to play
+    const mediaInfo = await this.mcs.getMedias('mediaSession', this._presenterEndpoint);
+    const { medias = {} } = mediaInfo;
+    const { mediaTypes = {} } = medias;
+    if (mediaTypes.audio) {
+      this.presenterHasAudio = true;
+    }
     const dsrbstam = Messaging.generateScreenshareRTMPBroadcastStartedEvent2x(this._voiceBridge,
-      this._voiceBridge, this._streamUrl, this._vw, this._vh, timestamp);
+      this._voiceBridge, this._streamUrl, this._vw, this._vh, timestamp, this.presenterHasAudio);
     this.bbbGW.publish(dsrbstam, C.FROM_VOICE_CONF_SYSTEM_CHAN);
     this._rtmpBroadcastStarted = true;
     Logger.info(LOG_PREFIX, `Sent startRtmpBroadcast for ${meetingId}`,

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -31,7 +31,7 @@ const KURENTO_REMB_PARAMS = config.util.cloneDeep(config.get('kurentoRembParams'
 const LOG_PREFIX = "[screenshare]";
 
 module.exports = class Screenshare extends BaseProvider {
-  constructor(id, bbbGW, voiceBridge, userId, vh, vw, meetingId, mcs) {
+  constructor(id, bbbGW, voiceBridge, userId, vh, vw, meetingId, mcs, hasAudio) {
     super(bbbGW);
     this.sfuApp = C.SCREENSHARE_APP;
     this.mcs = mcs;
@@ -56,6 +56,7 @@ module.exports = class Screenshare extends BaseProvider {
     this._recordingSubPath = 'screenshare';
     this._startRecordingEventFired = false;
     this._stopRecordingEventFired = false;
+    this.hasAudio = hasAudio;
     this.handleMCSCoreDisconnection = this.handleMCSCoreDisconnection.bind(this);
     this.mcs.on(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
   }
@@ -685,16 +686,8 @@ module.exports = class Screenshare extends BaseProvider {
     }
 
     const timestamp = Math.floor(new Date());
-    this.presenterHasAudio = false;
-    // Check if screenshare has audio to inform other participants they have to play
-    const mediaInfo = await this.mcs.getMedias('mediaSession', this._presenterEndpoint);
-    const { medias = {} } = mediaInfo;
-    const { mediaTypes = {} } = medias;
-    if (mediaTypes.audio) {
-      this.presenterHasAudio = true;
-    }
     const dsrbstam = Messaging.generateScreenshareRTMPBroadcastStartedEvent2x(this._voiceBridge,
-      this._voiceBridge, this._streamUrl, this._vw, this._vh, timestamp, this.presenterHasAudio);
+      this._voiceBridge, this._streamUrl, this._vw, this._vh, timestamp, this.hasAudio);
     this.bbbGW.publish(dsrbstam, C.FROM_VOICE_CONF_SYSTEM_CHAN);
     this._rtmpBroadcastStarted = true;
     Logger.info(LOG_PREFIX, `Sent startRtmpBroadcast for ${meetingId}`,


### PR DESCRIPTION
- Replaces #251.
- [mcs-core]: fixes audio+video bundling for monoadapter calls.
- [screenshare]: adds backwards-compatible support for screenshare bundled with audio.