### PR TITLE
[video] Fix server-side video eject on media timeout

### DIFF
--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -302,17 +302,13 @@ module.exports = class Video extends BaseProvider {
   }
 
   sendPlayStop () {
-    let userCamEvent =
-      Messaging.generateUserCamBroadcastStoppedEventMessage2x(this.meetingId, this.id, this.id);
-    this.bbbGW.publish(userCamEvent, C.TO_AKKA_APPS_CHAN_2x);
+    const userCamEvent = Messaging.generateUserCamBroadcastStoppedEventMessage2x(
+      this.meetingId,
+      this.bbbUserId,
+      this.id
+    );
 
-    this.bbbGW.publish(JSON.stringify({
-      connectionId: this.connectionId,
-      type: 'video',
-      role: this.role,
-      id : 'playStop',
-      cameraId: this.id,
-    }), C.FROM_VIDEO);
+    this.bbbGW.publish(userCamEvent, C.TO_AKKA_APPS_CHAN_2x);
   }
 
   /* ======= RECORDING METHODS ======= */


### PR DESCRIPTION
Video ejection on media timeout (server side) was broken due to a typo in the ejection message parameters.