### PR TITLE
[screenshare] Force mediaProfile on recording to avoid transcoding

### DIFF
--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -406,11 +406,11 @@ module.exports = class Screenshare extends BaseProvider {
       try {
         const contentCodec = DEFAULT_MEDIA_SPECS.codec_video_content;
         const recordingProfile = (contentCodec === 'VP8' || contentCodec === 'ANY')
-          ? this.hasAudio 
-            ? C.RECORDING_PROFILE_WEBM_FULL 
+          ? this.hasAudio
+            ? C.RECORDING_PROFILE_WEBM_FULL
             : C.RECORDING_PROFILE_WEBM_VIDEO_ONLY
-          : this.hasAudio 
-            ? C.RECORDING_PROFILE_MKV_FULL 
+          : this.hasAudio
+            ? C.RECORDING_PROFILE_MKV_FULL
             : C.RECORDING_PROFILE_MKV_VIDEO_ONLY;
         const format = (contentCodec === 'VP8' || contentCodec === 'ANY')
           ? C.RECORDING_FORMAT_WEBM
@@ -425,7 +425,7 @@ module.exports = class Screenshare extends BaseProvider {
           this.presenterMCSUserId,
           this._presenterEndpoint,
           recordingPath,
-          { recordingProfile, ignoreThresholds: true }
+          { recordingProfile, ignoreThresholds: true, mediaProfile: 'content' }
         );
         this.recording = { recordingId, filename: recordingPath };
         this.mcs.onEvent(C.MEDIA_STATE, this.recording.recordingId, (event) => {


### PR DESCRIPTION
By forcing `mediaProfile: 'content'` in the recording media session creation, we specifically bind it to the `content` type media server if MEDIA_TYPE is being used and the content media unit has bundled audio+video.

Otherwise, the mediaType parsing code would make the recorder endpoint go to the audio type media server, causing a weird VP8 -> H.264 -> VP8 transcoding when bridging the media between servers for recording. The transposing code is still experimental and bound to H.264.