### PR TITLE
v2.4.20

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -11,8 +11,8 @@ kurento:
       request_timeout: 30000
       response_timeout: 30000
 # Number of attemps of connecting to the configured kurento instances the first
-# time. Infinity means it tries forever until it's able to connect. Default is 10.
-kurentoStartupRetries: 10
+# time. Infinity means it tries forever until it's able to connect. Default is Infinity.
+kurentoStartupRetries: Infinity
 # balancing-strategy: can be either ROUND_ROBIN or MEDIA_TYPE. The MEDIA_TYPE only
 # works properly if you annotated the configured kurento instances in the
 # 'kurento' config parameter with a mediaType field (main|audio|content) which

--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -96,7 +96,8 @@ module.exports = class Kurento extends EventEmitter {
 
         this._pipelinePromises = this._pipelinePromises.filter(pp => pp.id !== roomId + hostId);
 
-        Logger.info(LOG_PREFIX, "Created pipeline at room", roomId, "with host", hostId, host.id, pipeline.id);
+        Logger.info(LOG_PREFIX, `Created pipeline at room ${roomId}`,
+          { hostId: host.id, pipeline: pipeline.id, roomId });
 
         return pipeline;
       }
@@ -121,7 +122,8 @@ module.exports = class Kurento extends EventEmitter {
   _releasePipeline (room, hostId) {
     return new Promise((resolve, reject) => {
       try {
-        Logger.debug(LOG_PREFIX, "Releasing room", room, "pipeline at host", hostId);
+        Logger.debug(LOG_PREFIX, `Releasing pipeline of room ${room}`,
+          { hostId, roomId: room });
         const pipeline = this._mediaPipelines[room][hostId];
         if (pipeline && typeof pipeline.release === 'function') {
           pipeline.release((error) => {
@@ -208,7 +210,7 @@ module.exports = class Kurento extends EventEmitter {
   }
 
   _negotiateSDPEndpoint (roomId, userId, mediaSessionId, descriptor, type, options) {
-    Logger.debug(LOG_PREFIX, "Negotiating SDP endpoint for", userId, "at", roomId);
+    Logger.debug(LOG_PREFIX, `Negotiating SDP endpoint`, { userId, roomId });
     try {
       // We strip the SDP into media units of the same type because Kurento can't handle
       // bundling other than audio + video
@@ -426,7 +428,13 @@ module.exports = class Kurento extends EventEmitter {
       try {
         const source = this._mediaElements[sourceId];
         const sink = this._mediaElements[sinkId];
-        Logger.info(LOG_PREFIX, "Transposing from", source.id, "| host", source.host.id,  "to", sink.id, "| host", sink.host.id);
+        Logger.info(LOG_PREFIX, `Transposing elements`, {
+          sourceId: source.id,
+          sourceHostId: source.host.id,
+          sinkId: sink.id,
+          sinkHostId: sink.host.id,
+        });
+
         let sourceTransposer, sinkTransposer, sourceOffer, sinkAnswer;
 
         sourceTransposer = source.transposers[sink.host.id];
@@ -434,7 +442,10 @@ module.exports = class Kurento extends EventEmitter {
         if (sourceTransposer == null) {
           source.transposers[sink.host.id] = {};
           this._transposingQueue.push(source.host.id+source.id+sink.host.id);
-          Logger.info(LOG_PREFIX, "Source transposer for", source.id, "to host", sink.host.id, "not found");
+
+          Logger.info(LOG_PREFIX, "Source transposer not found",
+            { sourceId: source.id, sinkHostId: sink.host.id });
+
           sourceTransposer = await this._createElement(source.pipeline, C.MEDIA_TYPE.RTP);
           source.transposers[sink.host.id] = sourceTransposer;
           sourceOffer = await this.generateOffer(sourceTransposer.id);
@@ -443,7 +454,12 @@ module.exports = class Kurento extends EventEmitter {
           sourceOffer = SdpWrapper.convertToString(filteredOffer);
           this.balancer.incrementHostStreams(source.host.id, C.MEDIA_PROFILE.MAIN);
 
-          Logger.info(LOG_PREFIX, "Sink transposer for pipeline", sink.pipeline.id, "for host", source.id, source.host.id, "not found");
+          Logger.info(LOG_PREFIX, "Sink transposer not found", {
+            sinkPipelineId: sink.pipeline.id,
+            sourceId: source.id,
+            sourceHostId: source.host.id,
+          });
+
           sink.pipeline.transposers[source.host.id+source.id] = sinkTransposer = await this._createElement(sink.pipeline, C.MEDIA_TYPE.RTP);
           sinkAnswer = await this.processOffer(sinkTransposer.id, SdpWrapper.stReplaceServerIpv4(sourceOffer, source.host.ip));
           await this.processAnswer(sourceTransposer.id, SdpWrapper.stReplaceServerIpv4(sinkAnswer, sink.host.ip));
@@ -623,7 +639,7 @@ module.exports = class Kurento extends EventEmitter {
   stop (room, type, elementId) {
     return new Promise(async (resolve, reject) => {
       try {
-        Logger.info(LOG_PREFIX, "Releasing endpoint", elementId, "from room", room);
+        Logger.info(LOG_PREFIX, `Releasing endpoint`, { elementId, roomId: room });
         const mediaElement = this._mediaElements[elementId];
 
         this._removeElementEventListeners(elementId);
@@ -642,7 +658,8 @@ module.exports = class Kurento extends EventEmitter {
             Object.keys(mediaElement.transposers).forEach(t => {
               setTimeout(() => {
                 mediaElement.transposers[t].release();
-                Logger.debug(LOG_PREFIX, "Releasing transposer", t, "for", elementId);
+                Logger.debug(LOG_PREFIX, `Releasing transposer`,
+                  { transposerId: t, elementId });
                 this.balancer.decrementHostStreams(hostId, C.MEDIA_PROFILE.MAIN);
               }, 0);
             });
@@ -673,7 +690,8 @@ module.exports = class Kurento extends EventEmitter {
               if (pipeline) {
                 pipeline.activeElements--;
 
-                Logger.info(LOG_PREFIX, "Pipeline has a total of", pipeline.activeElements, "active elements");
+                Logger.info(LOG_PREFIX, `Pipeline elements decreased for room ${room}`,
+                  { activeElements: pipeline.activeElements, roomId: room, hostId });
                 if (pipeline.activeElements <= 0) {
                   await this._releasePipeline(room, hostId);
                 }
@@ -688,7 +706,7 @@ module.exports = class Kurento extends EventEmitter {
           }
         }
         else {
-          Logger.warn(LOG_PREFIX, "Media element", elementId, "could not be found to stop");
+          Logger.warn(LOG_PREFIX, `Media element not found on stop`, { elementId });
           return resolve();
         }
       }
@@ -1021,7 +1039,7 @@ module.exports = class Kurento extends EventEmitter {
     let event;
     try {
       if (mediaElement) {
-        Logger.debug(LOG_PREFIX, 'Adding media state listener [' + eventTag + '] for ' + elementId);
+        Logger.debug(LOG_PREFIX, `Adding media state listener ${eventTag}`, { eventTag, elementId });
         mediaElement.on(eventTag, (rawEvent) => {
           const timestampUTC = Date.now();
           const timestampHR = Util.hrTime();
@@ -1062,7 +1080,7 @@ module.exports = class Kurento extends EventEmitter {
 
   _removeElementEventListeners (elementId) {
     const eventsToRemove = C.EVENT.ADAPTER_EVENTS.map(p => `${p}${elementId}`);
-    Logger.trace(LOG_PREFIX, "Removing all event listeners for", elementId);
+    Logger.trace(LOG_PREFIX, `Removing all event listeners for ${elementId}`);
     eventsToRemove.forEach(e => {
       this.removeAllListeners(e);
     });
@@ -1087,8 +1105,9 @@ module.exports = class Kurento extends EventEmitter {
           delete this._mediaElements[mek];
         }
       });
-    } catch (e) {
-      Logger.error(e);
+    } catch (error) {
+      Logger.error(LOG_PREFIX, `Error destroying elements from host ${hostId}`,
+        { error, hostId });
     }
   }
 

--- a/lib/mcs-core/lib/media/balancer.js
+++ b/lib/mcs-core/lib/media/balancer.js
@@ -22,6 +22,7 @@ const KMS_FAILOVER_TIMEOUT_MS = 15000;
 const KMS_DEFAULT_OPTIONS = {
   failAfter: 5,
 };
+const LOG_PREFIX = '[mcs-balancer]';
 
 let instance = null;
 
@@ -62,12 +63,14 @@ class Balancer extends EventEmitter {
             }
             catch (e) {
               host.retries++;
-              Logger.error(`[mcs-balancer] Failed to connect to candidate host ${JSON.stringify({ url, ip, retries})}`);
+              Logger.error(LOG_PREFIX, `Failed to connect to media server`,
+                { url, ip, mediaType, retries });
               setTimeout(() => tryToConnect(host), HOST_RETRY_TIMER);
             };
           }
         } else {
-          Logger.error(`[mcs-balancer] Maximum number of retries expired for host ${url} ${ip}`);
+          Logger.error(LOG_PREFIX, `Maximum number of retries expired for media server`,
+            { url, ip, mediaType, retries });
         }
       };
 
@@ -113,14 +116,18 @@ class Balancer extends EventEmitter {
   }
 
   async getHost (mediaType = C.MEDIA_PROFILE.ALL) {
-    Logger.info(`[mcs-balancer] Getting host for mediaType: ${mediaType}`);
-
     const host = this._fetchAvailableHost(mediaType);
     if (host == null) {
       throw C.ERROR.MEDIA_SERVER_OFFLINE;
     }
 
-    Logger.info("[mcs-balancer] Chosen host is", JSON.stringify({ id: host.id, url: host.url, ip: host.ip, mediaType: host.mediaType, medias: host.medias }));
+    Logger.info(LOG_PREFIX, `Got media server ${host.id}`, {
+      hostId: host.id,
+      url: host.url,
+      mediaType: host.mediaType,
+      targetMediaType: mediaType,
+    });
+
     return host;
   }
 
@@ -133,11 +140,14 @@ class Balancer extends EventEmitter {
       const { id } = host;
       this.removeHost(id);
       this.hosts.push(host);
-      Logger.info('[mcs-balancer] Available hosts =>', JSON.stringify(this.hosts.map(h => ({ url: h.url, ip: h.ip, mediaType: h.mediaType }))));
+
+      Logger.info(LOG_PREFIX, `New media server host added`,
+        { hostId: id, url: host.url, ip: host.ip, mediaType: host.mediaType });
+
       return;
     }
 
-    Logger.warn("[mcs-balancer] Undefined media server host, should not happen");
+    Logger.warn(LOG_PREFIX, `Undefined media server host on addHost, SHOULD NOT HAPPEN!`);
   }
 
   removeHost (hostId) {
@@ -146,17 +156,21 @@ class Balancer extends EventEmitter {
 
   decrementHostStreams (hostId, mediaType) {
     const host = this.retrieveHost(hostId);
+
     if (host) {
       host.medias[mediaType]--;
-      Logger.info(`[mcs-balancer] Host ${host.id} ${mediaType} streams decremented`, JSON.stringify(host.medias));
+      Logger.info(LOG_PREFIX, `Media server ${mediaType} streams decremented`,
+        { hostId: host.id, url: host.url, mediaType, [mediaType]: host.medias[mediaType] });
     }
   }
 
   incrementHostStreams (hostId, mediaType) {
     const host = this.retrieveHost(hostId);
+
     if (host) {
       host.medias[mediaType]++;
-      Logger.info(`[mcs-balancer] Host ${host.id} ${mediaType} streams incremented`, JSON.stringify(host.medias));
+      Logger.info(LOG_PREFIX, `Media server ${mediaType} streams incremented`,
+        { hostId: host.id, url: host.url, mediaType, [mediaType]: host.medias[mediaType] });
     }
   }
 
@@ -228,24 +242,26 @@ class Balancer extends EventEmitter {
 
   _monitorConnectionState (host) {
     const { id, client, url, ip } = host;
+
     try {
-      Logger.debug('[mcs-balancer] Monitoring connection state for host', id, 'at', url);
       client.on('disconnect', () => {
         this._onDisconnection(host);
       });
       client.on('reconnected', (sameSession) => {
         this._onReconnection(sameSession, host);
       });
-    }
-    catch (err) {
-      Logger.error('[mcs-balancer] Error on monitoring host', id, err);
+    } catch (error) {
+      Logger.error(LOG_PREFIX, `Error when trying to monitor media server`,
+        { hostId: id, url, ip, mediaType: host.mediaType });
     }
   }
 
   _onDisconnection (host) {
     try {
       const { client, id } = host;
-      Logger.error('[mcs-balancer] Host', id, 'was disconnected for some reason, will have to clean up all elements and notify users');
+
+      Logger.error(LOG_PREFIX, 'Media server disconnected',
+        { hostId: id, url: host.url, mediaType: host.mediaType });
       this.removeHost(id);
       this.emit(C.EVENT.MEDIA_SERVER_OFFLINE, id);
 
@@ -254,21 +270,24 @@ class Balancer extends EventEmitter {
       host.video = 0;
 
       this._reconnectToServer(host);
-    } catch (e) {
-      Logger.error('[mcs-balancer] Error trying to handle host disconnection', e);
+    } catch (error) {
+      Logger.error(LOG_PREFIX, `Error trying to handle media server disconnection`,
+        { hostId: host.id, url: host.url, mediaType: host.mediaType, error });
     }
   }
 
   _onReconnection (sameSession, host) {
     if (!sameSession) {
-      Logger.warn('[mcs-media] Media server reconnected, but it is not the same session');
+      Logger.warn(LOG_PREFIX, `Media server reconnected, not same session`,
+        { hostId: host.id, url: host.url, mediaType: host.mediaType });
       this._onDisconnection(host);
     }
   }
 
   _reconnectToServer (host) {
     const { client, id, url, options } = host;
-    Logger.info("[mcs-balancer] Reconnecting to host", id, url);
+    Logger.info(LOG_PREFIX, `Reconnecting to media server`,
+      { hostId: id, url, mediaType: host.mediaType });
     if (this._reconnectionRoutine[id] == null) {
       this._reconnectionRoutine[id] = setInterval(async () => {
         try {
@@ -291,12 +310,15 @@ class Balancer extends EventEmitter {
             clearInterval(this._reconnectionRoutine[id]);
             delete this._reconnectionRoutine[id];
             this.addHost(h);
-            Logger.warn("[mcs-media] Reconnection to media server succeeded", id, url);
-          }).catch(e => {
-            Logger.info("[mcs-balancer] Failed to reconnect to host", id);
+            Logger.warn(LOG_PREFIX, `Reconnection to media server succeeded`,
+              { hostId: id, url, mediaType: host.mediaType });
+          }).catch(error => {
+            Logger.error(LOG_PREFIX, `Failed to reconnect to media server`,
+              { hostId: id, url, mediaType: host.mediaType, error });
           });
-        } catch (err) {
-          Logger.info("[mcs-balancer] Failed to reconnect to host", id);
+        } catch (error) {
+          Logger.error(LOG_PREFIX, `Failed to reconnect to media server`,
+            { hostId: id, url, mediaType: host.mediaType, error });
         }
       }, HOST_RETRY_TIMER);
     }

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -402,11 +402,11 @@ module.exports = class Screenshare extends BaseProvider {
       try {
         const contentCodec = DEFAULT_MEDIA_SPECS.codec_video_content;
         const recordingProfile = (contentCodec === 'VP8' || contentCodec === 'ANY')
-          ? this.hasAudio 
-            ? C.RECORDING_PROFILE_WEBM_FULL 
+          ? this.hasAudio
+            ? C.RECORDING_PROFILE_WEBM_FULL
             : C.RECORDING_PROFILE_WEBM_VIDEO_ONLY
-          : this.hasAudio 
-            ? C.RECORDING_PROFILE_MKV_FULL 
+          : this.hasAudio
+            ? C.RECORDING_PROFILE_MKV_FULL
             : C.RECORDING_PROFILE_MKV_VIDEO_ONLY;
         const format = (contentCodec === 'VP8' || contentCodec === 'ANY')
           ? C.RECORDING_FORMAT_WEBM
@@ -421,7 +421,7 @@ module.exports = class Screenshare extends BaseProvider {
           this.presenterMCSUserId,
           this._presenterEndpoint,
           recordingPath,
-          { recordingProfile, ignoreThresholds: true }
+          { recordingProfile, ignoreThresholds: true, mediaProfile: 'content' }
         );
         this.recording = { recordingId, filename: recordingPath };
         this.mcs.onEvent(C.MEDIA_STATE, this.recording.recordingId, (event) => {

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -296,17 +296,13 @@ module.exports = class Video extends BaseProvider {
   }
 
   sendPlayStop () {
-    let userCamEvent =
-      Messaging.generateUserCamBroadcastStoppedEventMessage2x(this.meetingId, this.id, this.id);
-    this.bbbGW.publish(userCamEvent, C.TO_AKKA_APPS_CHAN_2x);
+    const userCamEvent = Messaging.generateUserCamBroadcastStoppedEventMessage2x(
+      this.meetingId,
+      this.bbbUserId,
+      this.id
+    );
 
-    this.bbbGW.publish(JSON.stringify({
-      connectionId: this.connectionId,
-      type: 'video',
-      role: this.role,
-      id : 'playStop',
-      cameraId: this.id,
-    }), C.FROM_VIDEO);
+    this.bbbGW.publish(userCamEvent, C.TO_AKKA_APPS_CHAN_2x);
   }
 
   /* ======= RECORDING METHODS ======= */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.19",
+  "version": "2.4.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -216,18 +216,18 @@
       "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
     },
     "kurento-client": {
-      "version": "git+https://github.com/Kurento/kurento-client-js.git#da7b2f6433d52eb8689e65e8e6e3990b90dc40a1",
-      "from": "git+https://github.com/Kurento/kurento-client-js.git#6.13.0",
+      "version": "git+https://github.com/Kurento/kurento-client-js.git#7836dfc942f628390935d7fc0b331c53d16ade5c",
+      "from": "git+https://github.com/Kurento/kurento-client-js.git#6.14.0",
       "requires": {
         "async": "^2.0.1",
         "error-tojson": "0.0.1",
         "es6-promise": "^4.0.5",
         "extend": "^3.0.0",
         "inherits": "^2.0.0",
-        "kurento-client-core": "6.13.0",
-        "kurento-client-elements": "6.13.0",
-        "kurento-client-filters": "6.13.0",
-        "kurento-jsonrpc": "6.13.0",
+        "kurento-client-core": "6.14.0",
+        "kurento-client-elements": "6.14.0",
+        "kurento-client-filters": "6.14.0",
+        "kurento-jsonrpc": "6.14.0",
         "minimist": "^1.2.0",
         "promise": "7.1.1",
         "promisecallback": "0.0.4",
@@ -235,24 +235,24 @@
       }
     },
     "kurento-client-core": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/kurento-client-core/-/kurento-client-core-6.13.0.tgz",
-      "integrity": "sha512-ox8FiQ28L5wjc7lGfdMVpXy4HsLn1dK5pFn79sshUB817qQaWewLLNtAt9D00B0nSfzCqqRio178u1l/0M7+wA=="
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/kurento-client-core/-/kurento-client-core-6.14.0.tgz",
+      "integrity": "sha512-jXQEjqu8EsoK2Gpkv6IUsCB5BYC9WJPVmEHoC+vx4uzRx5Kzwn6h+n7+eRTczUJOfn374BONFdvuSvBG6UJ0Kw=="
     },
     "kurento-client-elements": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/kurento-client-elements/-/kurento-client-elements-6.13.0.tgz",
-      "integrity": "sha512-iiAbe1Ts5Xp5NXWgmyQour9UYzPiCpLGG0drLhLGwpeWn8lbkJneYAsI2GG8tXlxVJTi9Uxv4FLwniO+26+lwg=="
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/kurento-client-elements/-/kurento-client-elements-6.14.0.tgz",
+      "integrity": "sha512-DcJ1bXTS3kr36d/r7WVF98ahMrV/rsENTr/qg9g6iCCY3RtIUrllhtPj7UABSPIMiX7FYF0m8Hq52rTAh8TWuA=="
     },
     "kurento-client-filters": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/kurento-client-filters/-/kurento-client-filters-6.13.0.tgz",
-      "integrity": "sha512-hpM57St5VvRT+c2pv7DE/rTo3d1QayTdCWTqICR/6OtbRgP/rmP+eGY2LmqO/OpR+t2Koz4fzLcLMII03UZ16Q=="
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/kurento-client-filters/-/kurento-client-filters-6.14.0.tgz",
+      "integrity": "sha512-ch9/6dEBk+3zyf5ISax8Ep530Q3bKWwTZ+QMLM6ZGbTJLDTWYZHzFLCBBPvy53iUPO0aKFdZ0CHDfOkrQgyG8g=="
     },
     "kurento-jsonrpc": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/kurento-jsonrpc/-/kurento-jsonrpc-6.13.0.tgz",
-      "integrity": "sha512-irHHeXGtEwc/0UNNmUtFl480enC8m6W1x6F/MEeMmb8DAsxWO9NOvp2E0ZScqYZomPx+K63kqoLGF619bV4J5w==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/kurento-jsonrpc/-/kurento-jsonrpc-6.14.0.tgz",
+      "integrity": "sha512-gM7uu5KU57nPFkZbvwFY5tVP7X2sFkVflnBgipdk6zsxrKHvW6ZUfQIdESnxWylFFRj66wdes9mI3ro+DbpWZw==",
       "requires": {
         "bufferutil": "^4.0.1",
         "inherits": "^2.0.1",
@@ -260,16 +260,16 @@
       },
       "dependencies": {
         "ws": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
         }
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "mcs-js": {
       "version": "git+https://github.com/mconftec/mcs-js.git#94292a211164704f850128e95602d6d99056bf55",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "config": "1.30.0",
     "ipaddr.js": "1.9.1",
     "js-yaml": "3.13.1",
-    "kurento-client": "git+https://github.com/Kurento/kurento-client-js.git#6.13.0",
+    "kurento-client": "git+https://github.com/Kurento/kurento-client-js.git#6.14.0",
     "mcs-js": "git+https://github.com/mconftec/mcs-js.git#v0.0.9",
     "modesl": "1.2.1",
     "pegjs": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.19",
+  "version": "2.4.20",
   "private": true,
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
Patch release v2.4.20.

__CHANGELOG__:

This patch release backports a few fixes and logging improvements from v2.5.x. Mainly:
  -  [mcs-core/kurento] Sanitize some old logs dbc25d0
  -  [video] Fix server-side video eject on media timeout a60cf69
  -  [mcs-core/kurento] Bump default startup retries number to infinity 13c0f53
  -  [mcs-core/balancer]: refactor logging 3013704
  -  [screenshare] Force mediaProfile on recording to avoid accidental transcoding when source has audio+video 5e2de38 
  -  Bump kurento-client to 6.14.0 d1156d6 