### PR TITLE
v2.4.22

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -75,6 +75,9 @@ videoSubscriberSpecSlave:
 screenshareSubscriberSpecSlave:
   __name: SCREENSHARE_SUBSCRIBER_SLAVE
   __format: json
+screensharePlayStartEnabled:
+  __name: SCREENSHARE_PLAY_START_ENABLED
+  __format: json
 
 kurentoAllowedCandidateIps:
   __name: KURENTO_ALLOWED_CANDIDATE_IPS

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -45,6 +45,7 @@ common-message-version: 2.x
 screenshareKeyframeInterval: 0
 screenshareEnableFlashRTPBridge: false
 screenshareSubscriberSpecSlave: false
+screensharePlayStartEnabled: false
 videoSubscriberSpecSlave: false
 
 recordScreenSharing: true

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -27,6 +27,9 @@ const SUBSCRIBER_SPEC_SLAVE = config.has('videoSubscriberSpecSlave')
   ? config.get('videoSubscriberSpecSlave')
   : false;
 const KURENTO_REMB_PARAMS = config.util.cloneDeep(config.get('kurentoRembParams'));
+const SCREENSHARE_PLAY_START_ENABLED = config.has(`screensharePlayStartEnabled`)
+  ? config.get(`screensharePlayStartEnabled`)
+  : false;
 
 const LOG_PREFIX = "[screenshare]";
 
@@ -187,12 +190,14 @@ module.exports = class Screenshare extends BaseProvider {
   }
 
   sendPlayStart (role, connectionId) {
-    this.bbbGW.publish(JSON.stringify({
-      type: C.SCREENSHARE_APP,
-      id : 'playStart',
-      connectionId,
-      role,
-    }), C.FROM_SCREENSHARE);
+    if (SCREENSHARE_PLAY_START_ENABLED) {
+      this.bbbGW.publish(JSON.stringify({
+        type: C.SCREENSHARE_APP,
+        id : 'playStart',
+        connectionId,
+        role,
+      }), C.FROM_SCREENSHARE);
+    }
   }
 
   _onViewerWebRTCMediaFlowing (connectionId) {

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -302,6 +302,14 @@ module.exports = class Video extends BaseProvider {
       this.id
     );
 
+    this.bbbGW.publish(JSON.stringify({
+      connectionId: this.connectionId,
+      type: 'video',
+      role: this.role,
+      id : 'playStop',
+      cameraId: this.id,
+    }), C.FROM_VIDEO);
+
     this.bbbGW.publish(userCamEvent, C.TO_AKKA_APPS_CHAN_2x);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.21",
+  "version": "2.4.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.21",
+  "version": "2.4.22",
   "private": true,
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
Patch release v2.4.22.

__CHANGELOG__

-  [screenshare] Add playStart response on media flowing event. Configured and disabled by default. 6521402 5c2fbb5
-  [screenshare] Fix startViewer catch-all error handling 10bd154
-  [video] Try to fix an issue where the stop recording event wouldn`t be emitted when a camera was ejected by the server due to a media timeout 2464665