### PR TITLE
v2.4.23

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -78,6 +78,9 @@ screenshareSubscriberSpecSlave:
 screensharePlayStartEnabled:
   __name: SCREENSHARE_PLAY_START_ENABLED
   __format: json
+screenshareServerSideAkkaBroadcast:
+  __name: SCREENSHARE_SERVER_AKKA_BROADCAST
+  __format: json
 
 kurentoAllowedCandidateIps:
   __name: KURENTO_ALLOWED_CANDIDATE_IPS

--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -86,6 +86,10 @@ kurentoAllowedCandidateIps:
   __name: KURENTO_ALLOWED_CANDIDATE_IPS
   __format: json
 
+kurentoAllowMDNSCandidates:
+  __name: KURENTO_ALLOW_MDNS
+  __format: json
+
 mediaThresholds:
   global: GLOBAL_MEDIA_THRESHOLD
   perRoom: ROOM_MEDIA_THRESHOLD

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -46,6 +46,7 @@ screenshareKeyframeInterval: 0
 screenshareEnableFlashRTPBridge: false
 screenshareSubscriberSpecSlave: false
 screensharePlayStartEnabled: false
+screenshareServerSideAkkaBroadcast: true
 videoSubscriberSpecSlave: false
 
 recordScreenSharing: true

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -13,6 +13,8 @@ kurento:
 # Number of attemps of connecting to the configured kurento instances the first
 # time. Infinity means it tries forever until it's able to connect. Default is Infinity.
 kurentoStartupRetries: Infinity
+# Whether to allow Kurento to process mDNS ICE candidates
+kurentoAllowMDNSCandidates: true
 # balancing-strategy: can be either ROUND_ROBIN or MEDIA_TYPE. The MEDIA_TYPE only
 # works properly if you annotated the configured kurento instances in the
 # 'kurento' config parameter with a mediaType field (main|audio|content) which

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -38,7 +38,6 @@ const config = require('config');
 
         // Redis channels
         FROM_BBB_TRANSCODE_SYSTEM_CHAN : "bigbluebutton:from-bbb-transcode:system",
-        FROM_VOICE_CONF_SYSTEM_CHAN: "from-voice-conf-redis-channel",
         TO_BBB_TRANSCODE_SYSTEM_CHAN: "bigbluebutton:to-bbb-transcode:system",
         TO_BBB_MEETING_CHAN: "bigbluebutton:to-bbb-apps:meeting",
         FROM_BBB_MEETING_CHAN: "bigbluebutton:from-bbb-apps:meeting",

--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -13,11 +13,14 @@ const SdpWrapper = require('../../utils/sdp-wrapper');
 const GLOBAL_EVENT_EMITTER = require('../../utils/emitter');
 const SDPMedia = require('../../model/sdp-media');
 const RecordingMedia = require('../../model/recording-media');
+
 const KURENTO_REMB_PARAMS = config.get('kurentoRembParams');
 const ALLOWED_CANDIDATE_IPS = config.has('kurentoAllowedCandidateIps')
   ? config.get('kurentoAllowedCandidateIps')
   : [];
-
+const KURENTO_ALLOW_MDNS = config.has('kurentoAllowMDNSCandidates')
+  ? config.get('kurentoAllowMDNSCandidates')
+  : false;
 const LOG_PREFIX = "[mcs-kurento-adapter]";
 const VANILLA_GATHERING_TIMEOUT = 30000;
 
@@ -720,10 +723,6 @@ module.exports = class Kurento extends EventEmitter {
   _checkForMDNSCandidate (candidate) {
     // Temporary stub for ignoring mDNS .local candidates. It'll just check
     // for it and make the calling procedure resolve if it's a mDNS.
-    // The commented code below is a general procedure to enabling mDNS
-    // lookup. We just gotta find a proper librabry or way to do it once the
-    // time is right
-
     const mDNSRegex = /([\d\w-]*)(.local)/ig
     if (candidate.match(/.local/ig)) {
       return true;
@@ -736,7 +735,8 @@ module.exports = class Kurento extends EventEmitter {
       const mediaElement = this._mediaElements[elementId];
       try {
         if (mediaElement  && candidate) {
-          if (this._checkForMDNSCandidate(candidate.candidate)) {
+          if (this._checkForMDNSCandidate(candidate.candidate) &&
+            !KURENTO_ALLOW_MDNS) {
             Logger.trace(LOG_PREFIX, "Ignoring a mDNS obfuscated candidate", candidate.candidate);
             return resolve();
           }

--- a/lib/screenshare/ScreenshareManager.js
+++ b/lib/screenshare/ScreenshareManager.js
@@ -46,7 +46,7 @@ module.exports = class ScreenshareManager extends BaseManager {
     switch (message.id) {
       case 'start':
         if (!session) {
-          const { vh, vw, internalMeetingId } = message;
+          const { vh = 0, vw = 0, internalMeetingId } = message;
           session = new Screenshare(connectionId, this._bbbGW,
             voiceBridge, connectionId, vh, vw,
             internalMeetingId, this.mcs, hasAudio);

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -30,6 +30,9 @@ const KURENTO_REMB_PARAMS = config.util.cloneDeep(config.get('kurentoRembParams'
 const SCREENSHARE_PLAY_START_ENABLED = config.has(`screensharePlayStartEnabled`)
   ? config.get(`screensharePlayStartEnabled`)
   : false;
+const SCREENSHARE_SERVER_AKKA_BROADCAST = config.has(`screenshareServerSideAkkaBroadcast`)
+  ? config.get(`screenshareServerSideAkkaBroadcast`)
+  : true;
 
 const LOG_PREFIX = "[screenshare]";
 
@@ -690,21 +693,23 @@ module.exports = class Screenshare extends BaseProvider {
   }
 
   _startRtmpBroadcast (meetingId, output) {
-    // If output is defined, we're using a RTMP url for the flash bridge
-    // Else just pass the WebRTC stream name
-    if (output) {
-      this._streamUrl = MediaHandler.generateStreamUrl(localIpAddress, meetingId, output);
-    } else {
-      this._streamUrl = this._presenterEndpoint;
-    }
+    if (SCREENSHARE_SERVER_AKKA_BROADCAST) {
+      // If output is defined, we're using a RTMP url for the flash bridge
+      // Else just pass the WebRTC stream name
+      if (output) {
+        this._streamUrl = MediaHandler.generateStreamUrl(localIpAddress, meetingId, output);
+      } else {
+        this._streamUrl = this._presenterEndpoint;
+      }
 
-    const timestamp = Math.floor(new Date());
-    const dsrbstam = Messaging.generateScreenshareRTMPBroadcastStartedEvent2x(this._voiceBridge,
-      this._voiceBridge, this._streamUrl, this._vw, this._vh, timestamp, this.hasAudio);
-    this.bbbGW.publish(dsrbstam, C.TO_AKKA_APPS);
-    this._rtmpBroadcastStarted = true;
-    Logger.info(LOG_PREFIX, `Sent startRtmpBroadcast for ${meetingId}`,
-      this._getPartialLogMetadata());
+      const timestamp = Math.floor(new Date());
+      const dsrbstam = Messaging.generateScreenshareRTMPBroadcastStartedEvent2x(this._voiceBridge,
+        this._voiceBridge, this._streamUrl, this._vw, this._vh, timestamp, this.hasAudio);
+      this.bbbGW.publish(dsrbstam, C.TO_AKKA_APPS);
+      this._rtmpBroadcastStarted = true;
+      Logger.info(LOG_PREFIX, `Sent startRtmpBroadcast for ${meetingId}`,
+        this._getPartialLogMetadata());
+    }
   }
 
   /* ======= STOP PROCEDURES ======= */

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -701,7 +701,7 @@ module.exports = class Screenshare extends BaseProvider {
     const timestamp = Math.floor(new Date());
     const dsrbstam = Messaging.generateScreenshareRTMPBroadcastStartedEvent2x(this._voiceBridge,
       this._voiceBridge, this._streamUrl, this._vw, this._vh, timestamp, this.hasAudio);
-    this.bbbGW.publish(dsrbstam, C.FROM_VOICE_CONF_SYSTEM_CHAN);
+    this.bbbGW.publish(dsrbstam, C.TO_AKKA_APPS);
     this._rtmpBroadcastStarted = true;
     Logger.info(LOG_PREFIX, `Sent startRtmpBroadcast for ${meetingId}`,
       this._getPartialLogMetadata());
@@ -801,7 +801,7 @@ module.exports = class Screenshare extends BaseProvider {
       const timestamp = Math.floor(new Date());
       const dsrstom = Messaging.generateScreenshareRTMPBroadcastStoppedEvent2x(this._voiceBridge,
         this._voiceBridge, this._streamUrl, this._vw, this._vh, timestamp);
-      this.bbbGW.publish(dsrstom, C.FROM_VOICE_CONF_SYSTEM_CHAN);
+      this.bbbGW.publish(dsrstom, C.TO_AKKA_APPS);
       Logger.info(LOG_PREFIX, `Sent stopRtmpBroadcast for ${meetingId}`,
         this._getPartialLogMetadata());
       resolve();

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -803,6 +803,7 @@ module.exports = class Screenshare extends BaseProvider {
 
   _stopRtmpBroadcast (meetingId) {
     return new Promise((resolve, reject) => {
+      if (!SCREENSHARE_SERVER_AKKA_BROADCAST) return resolve();
       const timestamp = Math.floor(new Date());
       const dsrstom = Messaging.generateScreenshareRTMPBroadcastStoppedEvent2x(this._voiceBridge,
         this._voiceBridge, this._streamUrl, this._vw, this._vh, timestamp);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.22",
+  "version": "2.4.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.22",
+  "version": "2.4.23",
   "private": true,
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
Patch release v2.4.23

__CHANGELOG__:

- [screenshare] Add default values to vw/vh, soon to be deprecated 51e31a7
- [screenshare] RTMP broadcast: use akka-apps inbound channel 71e4ffc
- [screenshare] Make server-side akka-apps RTMP broadcast messaging optional c4a262a
  - `screenshareServerSideAkkaBroadcast`/`SCREENSHARE_SERVER_AKKA_BROADCAST`: true|false
- [kurento] Make mDNS candidate filtering configurable
  - Support for mDNS candidates got in an acceptable state, enable it by default
  - New config and env variables to toggle the filtering: `kurentoAllowMDNSCandidates`/`KURENTO_ALLOW_MDNS`: true|false