### PR TITLE
Implement akka-apps media permission probes, improve user left and meeting end cleanup triggers

### DIFF
--- a/lib/audio/AudioManager.js
+++ b/lib/audio/AudioManager.js
@@ -45,6 +45,11 @@ module.exports = class AudioManager extends BaseManager {
           this._disconnectAllUsers(meetingId);
         });
         this._bbbGW.on(C.USER_JOINED_VOICE_CONF_MESSAGE_2x, this._handleUserJoinedVoiceConf.bind(this));
+        this._bbbGW.on(C.USER_LEFT_MEETING_2x, (payload) => {
+          let meetingId = payload[C.MEETING_ID_2x];
+          let userId = payload[C.USER_ID_2x];
+          this._disconnectUser(meetingId, userId);
+        });
     }
   }
 
@@ -92,6 +97,7 @@ module.exports = class AudioManager extends BaseManager {
 
     switch (message.id) {
       case 'start':
+        let permissionProbeDone = false;
         const handleSessionWideStartError = (errorMessage) => {
           errorMessage.id = 'webRTCAudioError';
           this._stopSession(sessionId);
@@ -116,6 +122,13 @@ module.exports = class AudioManager extends BaseManager {
           this._sessions[sessionId] = {}
           this._sessions[sessionId] = session;
           try {
+            await session.getGlobalAudioPermission(
+              session.meetingId,
+              session.voiceBridge,
+              message.userId,
+              connectionId
+            );
+            permissionProbeDone = true;
             await session.upstartSourceAudio(message.sdpOffer, message.caleeName);
           } catch (error) {
             const errorMessage = this._handleError(this._logPrefix, connectionId, message.calleeName, C.RECV_ROLE, error);
@@ -126,7 +139,7 @@ module.exports = class AudioManager extends BaseManager {
         this._meetings[message.internalMeetingId] = sessionId;
 
         // starts audio session by sending sessionID, websocket and sdpoffer
-        session.start(sessionId, connectionId, message.sdpOffer, message.caleeName, message.userId, message.userName, (error, sdpAnswer) => {
+        session.start(sessionId, connectionId, message.sdpOffer, message.caleeName, message.userId, message.userName, permissionProbeDone, (error, sdpAnswer) => {
           if (error) {
             const errorMessage = this._handleError(this._logPrefix, connectionId, null, C.RECV_ROLE, error);
             return handleListenerStartError(errorMessage);

--- a/lib/audio/AudioManager.js
+++ b/lib/audio/AudioManager.js
@@ -82,7 +82,20 @@ module.exports = class AudioManager extends BaseManager {
       let session = this._sessions[sessionId];
       if (typeof session !== 'undefined') {
         let connectionId = session.getConnectionId(userId);
-        if (connectionId) session.stopListener(connectionId);
+        if (connectionId) {
+          Logger.info(this._logPrefix, 'Disconnect a listen only session on UserLeft*', {
+            meetingId,
+            userId,
+            sessionId,
+            connectionId,
+          });
+          session.stopListener(connectionId);
+          this._bbbGW.publish(JSON.stringify({
+            connectionId,
+            type: C.AUDIO_APP,
+            id : 'close',
+          }), C.FROM_AUDIO);
+        }
       }
     }
   }

--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -170,6 +170,26 @@ module.exports = class Audio extends BaseProvider {
       this._getPartialLogMetadata());
    };
 
+  getGlobalAudioPermission (meetingId, voiceBridge, userId, sfuSessionId) {
+    return new Promise((resolve, reject) => {
+      const onResp = (payload) => {
+        const { meetingId, voiceBridge, userId, allowed } = payload;
+        if (meetingId === payload.meetingId
+          && payload.voiceBridge === voiceBridge
+          && payload.userId === userId
+          && payload.allowed) {
+          return resolve();
+        }
+
+        return reject(errors.SFU_UNAUTHORIZED);
+      }
+
+      const msg = Messaging.generateGetGlobalAudioPermissionReqMsg(meetingId, voiceBridge, userId, sfuSessionId);
+      this.bbbGW.once(C.GET_GLOBAL_AUDIO_PERM_RESP_MSG+sfuSessionId, onResp);
+      this.bbbGW.publish(msg, C.TO_AKKA_APPS_CHAN_2x);
+    });
+  }
+
   /* ======= MEDIA TIMEOUT HANDLERS ===== */
 
   _onSubscriberMediaFlowing (connectionId) {
@@ -493,8 +513,12 @@ module.exports = class Audio extends BaseProvider {
     });
   }
 
-  async start (sessionId, connectionId, sdpOffer, calleeName, userId, userName, callback) {
+  async start (sessionId, connectionId, sdpOffer, calleeName, userId, userName, permissionProbeDone, callback) {
     try {
+      if (!permissionProbeDone) {
+        await this.getGlobalAudioPermission(this.meetingId, this.voiceBridge, userId, connectionId);
+      }
+
       const isConnected = await this.mcs.waitForConnection();
 
       if (!isConnected) {

--- a/lib/base/BaseManager.js
+++ b/lib/base/BaseManager.js
@@ -93,7 +93,6 @@ module.exports = class BaseManager {
 
   _stopSession (sessionId) {
     return new Promise(async (resolve, reject) => {
-      Logger.info(this._logPrefix, 'Stopping session ' + sessionId);
       try {
         if (this._sessions == null || sessionId == null) {
           return resolve();
@@ -101,6 +100,7 @@ module.exports = class BaseManager {
 
         let session = this._sessions[sessionId];
         if (session) {
+          Logger.info(this._logPrefix, `Stopping session ${sessionId}`);
           if (typeof session.stop === 'function') {
             await session.stop();
           }

--- a/lib/base/errors.js
+++ b/lib/base/errors.js
@@ -16,6 +16,7 @@ const errorCodes =  {
   2210: "MEDIA_CONNECT_ERROR",
   2211: "MEDIA_NOT_FLOWING",
   2300: "SFU_INVALID_REQUEST",
+  2301: "SFU_UNAUTHORIZED",
 }
 
 const expandErrors = () => {

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -94,6 +94,10 @@ const config = require('config');
         GET_SCREEN_BROADCAST_PERM_RESP_MSG: "GetScreenBroadcastPermissionRespMsg",
         GET_SCREEN_SUBSCRIBE_PERM_REQ_MSG: "GetScreenSubscribePermissionReqMsg",
         GET_SCREEN_SUBSCRIBE_PERM_RESP_MSG: "GetScreenSubscribePermissionRespMsg",
+        GET_CAM_BROADCAST_PERM_REQ_MSG: "GetCamBroadcastPermissionReqMsg",
+        GET_CAM_BROADCAST_PERM_RESP_MSG: "GetCamBroadcastPermissionRespMsg",
+        GET_CAM_SUBSCRIBE_PERM_REQ_MSG: "GetCamSubscribePermissionReqMsg",
+        GET_CAM_SUBSCRIBE_PERM_RESP_MSG: "GetCamSubscribePermissionRespMsg",
 
         STREAM_IS_RECORDED: "StreamIsRecordedMsg",
 

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -88,6 +88,8 @@ const config = require('config');
         PRESENTER_ASSIGNED_2x: "PresenterAssignedEvtMsg",
         USER_JOINED_VOICE_CONF_MESSAGE_2x: "UserJoinedVoiceConfToClientEvtMsg",
         USER_LEFT_MEETING_2x: "UserLeftMeetingEvtMsg",
+        GET_GLOBAL_AUDIO_PERM_REQ_MSG: "GetGlobalAudioPermissionReqMsg",
+        GET_GLOBAL_AUDIO_PERM_RESP_MSG: "GetGlobalAudioPermissionRespMsg",
 
         STREAM_IS_RECORDED: "StreamIsRecordedMsg",
 
@@ -95,16 +97,16 @@ const config = require('config');
         STOP_WEBCAM_SHARE: "StopWebRTCShareEvent",
 
         // Redis messages fields
-        //  Transcoder 1x
         USER_ID : "user_id",
         OPTIONS: "options",
         VOICE_CONF_ID : "voice_conf_id",
         TRANSCODER_ID : "transcoder_id",
 
-        // Transcoder 2x
         USER_ID_2x : "userId",
         TRANSCODER_ID_2x : "transcoderId",
         MEETING_ID_2x: "meetingId",
+        VOICE_CONF_2x: "voiceConf",
+        SFU_SESSION_ID: "sfuSessionId",
 
         // Akka Apps 2x
         REQUESTED_BY: "requestedBy",

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -90,6 +90,10 @@ const config = require('config');
         USER_LEFT_MEETING_2x: "UserLeftMeetingEvtMsg",
         GET_GLOBAL_AUDIO_PERM_REQ_MSG: "GetGlobalAudioPermissionReqMsg",
         GET_GLOBAL_AUDIO_PERM_RESP_MSG: "GetGlobalAudioPermissionRespMsg",
+        GET_SCREEN_BROADCAST_PERM_REQ_MSG: "GetScreenBroadcastPermissionReqMsg",
+        GET_SCREEN_BROADCAST_PERM_RESP_MSG: "GetScreenBroadcastPermissionRespMsg",
+        GET_SCREEN_SUBSCRIBE_PERM_REQ_MSG: "GetScreenSubscribePermissionReqMsg",
+        GET_SCREEN_SUBSCRIBE_PERM_RESP_MSG: "GetScreenSubscribePermissionRespMsg",
 
         STREAM_IS_RECORDED: "StreamIsRecordedMsg",
 
@@ -107,6 +111,7 @@ const config = require('config');
         MEETING_ID_2x: "meetingId",
         VOICE_CONF_2x: "voiceConf",
         SFU_SESSION_ID: "sfuSessionId",
+        STREAM_ID: "streamId",
 
         // Akka Apps 2x
         REQUESTED_BY: "requestedBy",

--- a/lib/bbb/messages/Messaging.js
+++ b/lib/bbb/messages/Messaging.js
@@ -36,6 +36,11 @@ const GetScreenBroadcastPermissionReqMsg =
     require('./screenshare/GetScreenBroadcastPermissionReqMsg.js')(Constants);
 const GetScreenSubscribePermissionReqMsg=
     require('./screenshare/GetScreenSubscribePermissionReqMsg.js')(Constants);
+const GetCamBroadcastPermissionReqMsg =
+    require('./video/GetCamBroadcastPermissionReqMsg.js')(Constants);
+const GetCamSubscribePermissionReqMsg=
+    require('./video/GetCamSubscribePermissionReqMsg.js')(Constants);
+
 
 /**
  * @classdesc
@@ -152,6 +157,28 @@ Messaging.prototype.generateGetScreenSubscribePermissionReqMsg = (
   return (new GetScreenSubscribePermissionReqMsg(
     meetingId,
     voiceConf,
+    userId,
+    streamId,
+    sfuSessionId
+  )).toJson();
+}
+
+Messaging.prototype.generateGetCamBroadcastPermissionReqMsg = (
+  meetingId,
+  userId,
+  sfuSessionId
+) => {
+  return (new GetCamBroadcastPermissionReqMsg(meetingId, userId, sfuSessionId)).toJson();
+}
+
+Messaging.prototype.generateGetCamSubscribePermissionReqMsg = (
+  meetingId,
+  userId,
+  streamId,
+  sfuSessionId
+) => {
+  return (new GetCamSubscribePermissionReqMsg(
+    meetingId,
     userId,
     streamId,
     sfuSessionId

--- a/lib/bbb/messages/Messaging.js
+++ b/lib/bbb/messages/Messaging.js
@@ -32,6 +32,10 @@ let UserDisconnectedFromGlobalAudio2x =
     require('./audio/UserDisconnectedFromGlobalAudio2x.js')(Constants);
 const GetGlobalAudioPermissionReqMsg =
     require('./audio/GetGlobalAudioPermissionReqMsg.js')(Constants);
+const GetScreenBroadcastPermissionReqMsg =
+    require('./screenshare/GetScreenBroadcastPermissionReqMsg.js')(Constants);
+const GetScreenSubscribePermissionReqMsg=
+    require('./screenshare/GetScreenSubscribePermissionReqMsg.js')(Constants);
 
 /**
  * @classdesc
@@ -120,9 +124,38 @@ Messaging.prototype.generateUserDisconnectedFromGlobalAudioMessage =
   return msg.toJson();
 }
 
-Messaging.prototype.generateGetGlobalAudioPermissionReqMsg = (meetingId, voiceConf, userId, sfuSessionId) => {
-  const msg = new GetGlobalAudioPermissionReqMsg(meetingId, voiceConf, userId, sfuSessionId);
-  return msg.toJson();
+Messaging.prototype.generateGetGlobalAudioPermissionReqMsg = (
+  meetingId,
+  voiceConf,
+  userId,
+  sfuSessionId
+) => {
+  return (new GetGlobalAudioPermissionReqMsg(meetingId, voiceConf, userId, sfuSessionId)).toJson();
+}
+
+Messaging.prototype.generateGetScreenBroadcastPermissionReqMsg = (
+  meetingId,
+  voiceConf,
+  userId,
+  sfuSessionId
+) => {
+  return (new GetScreenBroadcastPermissionReqMsg(meetingId, voiceConf, userId, sfuSessionId)).toJson();
+}
+
+Messaging.prototype.generateGetScreenSubscribePermissionReqMsg = (
+  meetingId,
+  voiceConf,
+  userId,
+  streamId,
+  sfuSessionId
+) => {
+  return (new GetScreenSubscribePermissionReqMsg(
+    meetingId,
+    voiceConf,
+    userId,
+    streamId,
+    sfuSessionId
+  )).toJson();
 }
 
 module.exports = new Messaging();

--- a/lib/bbb/messages/Messaging.js
+++ b/lib/bbb/messages/Messaging.js
@@ -1,7 +1,4 @@
 const Constants = require('./Constants.js');
-
-// Messages
-
 let OutMessage = require('./OutMessage.js');
 
 let StartTranscoderRequestMessage =
@@ -33,6 +30,8 @@ let UserConnectedToGlobalAudio2x =
     require('./audio/UserConnectedToGlobalAudio2x.js')(Constants);
 let UserDisconnectedFromGlobalAudio2x =
     require('./audio/UserDisconnectedFromGlobalAudio2x.js')(Constants);
+const GetGlobalAudioPermissionReqMsg =
+    require('./audio/GetGlobalAudioPermissionReqMsg.js')(Constants);
 
 /**
  * @classdesc
@@ -118,6 +117,11 @@ Messaging.prototype.generateUserDisconnectedFromGlobalAudioMessage =
     default:
       msg = new UserDisconnectedFromGlobalAudio2x(voiceConf, userId, name);
   }
+  return msg.toJson();
+}
+
+Messaging.prototype.generateGetGlobalAudioPermissionReqMsg = (meetingId, voiceConf, userId, sfuSessionId) => {
+  const msg = new GetGlobalAudioPermissionReqMsg(meetingId, voiceConf, userId, sfuSessionId);
   return msg.toJson();
 }
 

--- a/lib/bbb/messages/audio/GetGlobalAudioPermissionReqMsg.js
+++ b/lib/bbb/messages/audio/GetGlobalAudioPermissionReqMsg.js
@@ -1,5 +1,5 @@
-var inherits = require('inherits');
-var OutMessage2x = require('../OutMessage2x');
+const inherits = require('inherits');
+const OutMessage2x = require('../OutMessage2x');
 
 module.exports = function (C) {
   function GetGlobalAudioPermissionReqMsg (meetingId, voiceConf, userId, sfuSessionId) {

--- a/lib/bbb/messages/audio/GetGlobalAudioPermissionReqMsg.js
+++ b/lib/bbb/messages/audio/GetGlobalAudioPermissionReqMsg.js
@@ -1,0 +1,20 @@
+var inherits = require('inherits');
+var OutMessage2x = require('../OutMessage2x');
+
+module.exports = function (C) {
+  function GetGlobalAudioPermissionReqMsg (meetingId, voiceConf, userId, sfuSessionId) {
+    GetGlobalAudioPermissionReqMsg.super_.call(this, C.GET_GLOBAL_AUDIO_PERM_REQ_MSG,
+      { sender: 'bbb-webrtc-sfu' },
+      { meetingId, userId }
+    );
+
+    this.core.body = {};
+    this.core.body[C.MEETING_ID_2x] = meetingId;
+    this.core.body[C.VOICE_CONF_2x] = voiceConf;
+    this.core.body[C.USER_ID_2x] = userId;
+    this.core.body[C.SFU_SESSION_ID] = sfuSessionId;
+  };
+
+  inherits(GetGlobalAudioPermissionReqMsg, OutMessage2x);
+  return GetGlobalAudioPermissionReqMsg;
+}

--- a/lib/bbb/messages/screenshare/GetScreenBroadcastPermissionReqMsg.js
+++ b/lib/bbb/messages/screenshare/GetScreenBroadcastPermissionReqMsg.js
@@ -1,0 +1,20 @@
+var inherits = require('inherits');
+var OutMessage2x = require('../OutMessage2x');
+
+module.exports = function (C) {
+  function GetScreenBroadcastPermissionReqMsg (meetingId, voiceConf, userId, sfuSessionId) {
+    GetScreenBroadcastPermissionReqMsg.super_.call(this, C.GET_SCREEN_BROADCAST_PERM_REQ_MSG,
+      { sender: 'bbb-webrtc-sfu' },
+      { meetingId, userId }
+    );
+
+    this.core.body = {};
+    this.core.body[C.MEETING_ID_2x] = meetingId;
+    this.core.body[C.VOICE_CONF_2x] = voiceConf;
+    this.core.body[C.USER_ID_2x] = userId;
+    this.core.body[C.SFU_SESSION_ID] = sfuSessionId;
+  };
+
+  inherits(GetScreenBroadcastPermissionReqMsg, OutMessage2x);
+  return GetScreenBroadcastPermissionReqMsg;
+}

--- a/lib/bbb/messages/screenshare/GetScreenSubscribePermissionReqMsg.js
+++ b/lib/bbb/messages/screenshare/GetScreenSubscribePermissionReqMsg.js
@@ -1,5 +1,5 @@
-var inherits = require('inherits');
-var OutMessage2x = require('../OutMessage2x');
+const inherits = require('inherits');
+const OutMessage2x = require('../OutMessage2x');
 
 module.exports = function (C) {
   function GetScreenSubscribePermissionReqMsg (meetingId, voiceConf, userId, streamId, sfuSessionId) {

--- a/lib/bbb/messages/screenshare/GetScreenSubscribePermissionReqMsg.js
+++ b/lib/bbb/messages/screenshare/GetScreenSubscribePermissionReqMsg.js
@@ -1,0 +1,21 @@
+var inherits = require('inherits');
+var OutMessage2x = require('../OutMessage2x');
+
+module.exports = function (C) {
+  function GetScreenSubscribePermissionReqMsg (meetingId, voiceConf, userId, streamId, sfuSessionId) {
+    GetScreenSubscribePermissionReqMsg.super_.call(this, C.GET_SCREEN_SUBSCRIBE_PERM_REQ_MSG,
+      { sender: 'bbb-webrtc-sfu' },
+      { meetingId, userId }
+    );
+
+    this.core.body = {};
+    this.core.body[C.MEETING_ID_2x] = meetingId;
+    this.core.body[C.VOICE_CONF_2x] = voiceConf;
+    this.core.body[C.USER_ID_2x] = userId;
+    this.core.body[C.STREAM_ID] = streamId;
+    this.core.body[C.SFU_SESSION_ID] = sfuSessionId;
+  };
+
+  inherits(GetScreenSubscribePermissionReqMsg, OutMessage2x);
+  return GetScreenSubscribePermissionReqMsg;
+}

--- a/lib/bbb/messages/video/GetCamBroadcastPermissionReqMsg.js
+++ b/lib/bbb/messages/video/GetCamBroadcastPermissionReqMsg.js
@@ -2,19 +2,18 @@ const inherits = require('inherits');
 const OutMessage2x = require('../OutMessage2x');
 
 module.exports = function (C) {
-  function GetScreenBroadcastPermissionReqMsg (meetingId, voiceConf, userId, sfuSessionId) {
-    GetScreenBroadcastPermissionReqMsg.super_.call(this, C.GET_SCREEN_BROADCAST_PERM_REQ_MSG,
+  function GetCamBroadcastPermissionReqMsg (meetingId, userId, sfuSessionId) {
+    GetCamBroadcastPermissionReqMsg.super_.call(this, C.GET_CAM_BROADCAST_PERM_REQ_MSG,
       { sender: 'bbb-webrtc-sfu' },
       { meetingId, userId }
     );
 
     this.core.body = {};
     this.core.body[C.MEETING_ID_2x] = meetingId;
-    this.core.body[C.VOICE_CONF_2x] = voiceConf;
     this.core.body[C.USER_ID_2x] = userId;
     this.core.body[C.SFU_SESSION_ID] = sfuSessionId;
   };
 
-  inherits(GetScreenBroadcastPermissionReqMsg, OutMessage2x);
-  return GetScreenBroadcastPermissionReqMsg;
+  inherits(GetCamBroadcastPermissionReqMsg, OutMessage2x);
+  return GetCamBroadcastPermissionReqMsg;
 }

--- a/lib/bbb/messages/video/GetCamSubscribePermissionReqMsg.js
+++ b/lib/bbb/messages/video/GetCamSubscribePermissionReqMsg.js
@@ -2,19 +2,19 @@ const inherits = require('inherits');
 const OutMessage2x = require('../OutMessage2x');
 
 module.exports = function (C) {
-  function GetScreenBroadcastPermissionReqMsg (meetingId, voiceConf, userId, sfuSessionId) {
-    GetScreenBroadcastPermissionReqMsg.super_.call(this, C.GET_SCREEN_BROADCAST_PERM_REQ_MSG,
+  function GetCamSubscribePermissionReqMsg (meetingId, userId, streamId, sfuSessionId) {
+    GetCamSubscribePermissionReqMsg.super_.call(this, C.GET_CAM_SUBSCRIBE_PERM_REQ_MSG,
       { sender: 'bbb-webrtc-sfu' },
       { meetingId, userId }
     );
 
     this.core.body = {};
     this.core.body[C.MEETING_ID_2x] = meetingId;
-    this.core.body[C.VOICE_CONF_2x] = voiceConf;
     this.core.body[C.USER_ID_2x] = userId;
+    this.core.body[C.STREAM_ID] = streamId;
     this.core.body[C.SFU_SESSION_ID] = sfuSessionId;
   };
 
-  inherits(GetScreenBroadcastPermissionReqMsg, OutMessage2x);
-  return GetScreenBroadcastPermissionReqMsg;
+  inherits(GetCamSubscribePermissionReqMsg, OutMessage2x);
+  return GetCamSubscribePermissionReqMsg;
 }

--- a/lib/bbb/pubsub/bbb-gw.js
+++ b/lib/bbb/pubsub/bbb-gw.js
@@ -149,6 +149,12 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
         case C.GET_SCREEN_SUBSCRIBE_PERM_RESP_MSG:
           this.emit(C.GET_SCREEN_SUBSCRIBE_PERM_RESP_MSG+payload.sfuSessionId, payload);
           break;
+        case C.GET_CAM_BROADCAST_PERM_RESP_MSG:
+          this.emit(C.GET_CAM_BROADCAST_PERM_RESP_MSG+payload.sfuSessionId, payload);
+          break;
+        case C.GET_CAM_SUBSCRIBE_PERM_RESP_MSG:
+          this.emit(C.GET_CAM_SUBSCRIBE_PERM_RESP_MSG+payload.sfuSessionId, payload);
+          break;
         default:
           this.emit(C.GATEWAY_MESSAGE, msg);
       }

--- a/lib/bbb/pubsub/bbb-gw.js
+++ b/lib/bbb/pubsub/bbb-gw.js
@@ -143,6 +143,12 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
         case C.GET_GLOBAL_AUDIO_PERM_RESP_MSG:
           this.emit(C.GET_GLOBAL_AUDIO_PERM_RESP_MSG+payload.sfuSessionId, payload);
           break;
+        case C.GET_SCREEN_BROADCAST_PERM_RESP_MSG:
+          this.emit(C.GET_SCREEN_BROADCAST_PERM_RESP_MSG+payload.sfuSessionId, payload);
+          break;
+        case C.GET_SCREEN_SUBSCRIBE_PERM_RESP_MSG:
+          this.emit(C.GET_SCREEN_SUBSCRIBE_PERM_RESP_MSG+payload.sfuSessionId, payload);
+          break;
         default:
           this.emit(C.GATEWAY_MESSAGE, msg);
       }

--- a/lib/bbb/pubsub/bbb-gw.js
+++ b/lib/bbb/pubsub/bbb-gw.js
@@ -122,8 +122,10 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
           this.emit(C.RECORDING_STATUS_REPLY_MESSAGE_2x+meetingId, payload);
           break;
         case C.DISCONNECT_ALL_USERS_2x:
-          payload[C.MEETING_ID_2x] = header[C.MEETING_ID_2x];
+          meetingId = header[C.MEETING_ID_2x];
+          payload[C.MEETING_ID_2x] = meetingId;
           this.emit(C.DISCONNECT_ALL_USERS_2x, payload);
+          this.emit(C.DISCONNECT_ALL_USERS_2x+meetingId, payload);
           break;
         case C.PRESENTER_ASSIGNED_2x:
           meetingId = header[C.MEETING_ID_2x];
@@ -139,6 +141,7 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
           payload.meetingId = header.meetingId;
           payload.userId = header.userId;
           this.emit(C.USER_LEFT_MEETING_2x, payload);
+          this.emit(C.USER_LEFT_MEETING_2x+header.userId, payload);
           break;
         case C.GET_GLOBAL_AUDIO_PERM_RESP_MSG:
           this.emit(C.GET_GLOBAL_AUDIO_PERM_RESP_MSG+payload.sfuSessionId, payload);

--- a/lib/bbb/pubsub/bbb-gw.js
+++ b/lib/bbb/pubsub/bbb-gw.js
@@ -140,6 +140,9 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
           payload.userId = header.userId;
           this.emit(C.USER_LEFT_MEETING_2x, payload);
           break;
+        case C.GET_GLOBAL_AUDIO_PERM_RESP_MSG:
+          this.emit(C.GET_GLOBAL_AUDIO_PERM_RESP_MSG+payload.sfuSessionId, payload);
+          break;
         default:
           this.emit(C.GATEWAY_MESSAGE, msg);
       }

--- a/lib/screenshare/ScreenshareManager.js
+++ b/lib/screenshare/ScreenshareManager.js
@@ -20,8 +20,24 @@ module.exports = class ScreenshareManager extends BaseManager {
     this.sfuApp = C.SCREENSHARE_APP;
     this.messageFactory(this._onMessage);
     this._iceQueues = {};
+    this._meetingSessionMap = {};
+
+    this._trackMeetingEvents();
     this.mcs.on(C.MCS_CONNECTED, () => {
       this.mcs.onEvent('roomCreated', 'all', this._handleRoomCreated.bind(this));
+    });
+  }
+
+  _trackMeetingEvents () {
+    this._bbbGW.on(C.DISCONNECT_ALL_USERS_2x, (payload) => {
+      let meetingId = payload[C.MEETING_ID_2x];
+      this.disconnectAllUsers(meetingId);
+    });
+
+    this._bbbGW.on(C.USER_LEFT_MEETING_2x, (payload) => {
+      let meetingId = payload[C.MEETING_ID_2x];
+      let userId = payload[C.USER_ID_2x];
+      this.disconnectUser(meetingId, userId);
     });
   }
 
@@ -51,6 +67,7 @@ module.exports = class ScreenshareManager extends BaseManager {
             voiceBridge, connectionId, vh, vw,
             internalMeetingId, this.mcs, hasAudio);
           this._sessions[voiceBridge] = session;
+          this._meetingSessionMap[internalMeetingId] = voiceBridge;
         }
 
         // starts screenshare peer with role by sending sessionID, websocket and sdpoffer
@@ -203,5 +220,46 @@ module.exports = class ScreenshareManager extends BaseManager {
 
     Logger.warn(this._logPrefix, `No screensharing session found for ${sessionId} with connectionId ${connectionId} and role ${role}`);
     return Promise.resolve();
+  }
+
+  disconnectAllUsers(meetingId) {
+    const voiceBridge = this._meetingSessionMap[meetingId];
+    if (typeof voiceBridge !== 'undefined') {
+      const session = this._fetchSession(voiceBridge);
+      if (session) {
+        Logger.info(this._logPrefix, 'Disconnecting all screenshare sessions, meeting end', {
+          meetingId,
+          voiceBridge,
+        });
+        this._stopSession(voiceBridge);
+      }
+      delete this._meetingSessionMap[meetingId]
+    }
+  }
+
+  disconnectUser(meetingId, userId) {
+    const voiceBridge = this._meetingSessionMap[meetingId]
+    if (typeof voiceBridge !== 'undefined') {
+      const session = this._sessions[voiceBridge];
+      if (typeof session !== 'undefined') {
+        const found = session.getConnectionIdAndRole(userId);
+        if (found && found.connectionId && found.role) {
+          Logger.info(this._logPrefix, 'Disconnect a screen share on UserLeft*', {
+            meetingId,
+            userId,
+            voiceBridge,
+            connectionId: found.connectionId,
+            role: found.role,
+          });
+
+          this.closeSession(session, found.connectionId, found.role, voiceBridge);
+          this._bbbGW.publish(JSON.stringify({
+            connectionId: found.connectionId,
+            type: C.SCREENSHARE_APP,
+            id : 'close',
+          }), C.FROM_SCREENSHARE);
+        }
+      }
+    }
   }
 }

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -465,6 +465,57 @@ module.exports = class Screenshare extends BaseProvider {
 
   /* ======= STOP PROCEDURES ======= */
 
+  getBroadcastPermission (meetingId, voiceBridge, userId, sfuSessionId, role) {
+    return new Promise((resolve, reject) => {
+      const onResp = (payload) => {
+        const { meetingId, voiceBridge, userId, allowed } = payload;
+        if (meetingId === payload.meetingId
+          && payload.voiceBridge === voiceBridge
+          && payload.userId === userId
+          && payload.allowed) {
+          return resolve();
+        }
+
+        return reject(errors.SFU_UNAUTHORIZED);
+      }
+
+      const msg = Messaging.generateGetScreenBroadcastPermissionReqMsg(
+        meetingId,
+        voiceBridge,
+        userId,
+        sfuSessionId
+      );
+      this.bbbGW.once(C.GET_SCREEN_BROADCAST_PERM_RESP_MSG+sfuSessionId, onResp);
+      this.bbbGW.publish(msg, C.TO_AKKA_APPS_CHAN_2x);
+    });
+  }
+
+  getSubscribePermission (meetingId, voiceBridge, userId, streamId, sfuSessionId, role) {
+    return new Promise((resolve, reject) => {
+      const onResp = (payload) => {
+        const { meetingId, voiceBridge, userId, allowed } = payload;
+        if (meetingId === payload.meetingId
+          && payload.voiceBridge === voiceBridge
+          && payload.userId === userId
+          && payload.allowed) {
+          return resolve();
+        }
+
+        return reject(errors.SFU_UNAUTHORIZED);
+      }
+
+      const msg = Messaging.generateGetScreenSubscribePermissionReqMsg(
+        meetingId,
+        voiceBridge,
+        userId,
+        streamId,
+        sfuSessionId
+      );
+      this.bbbGW.once(C.GET_SCREEN_SUBSCRIBE_PERM_RESP_MSG+sfuSessionId, onResp);
+      this.bbbGW.publish(msg, C.TO_AKKA_APPS_CHAN_2x);
+    });
+  }
+
   start (sessionId, connectionId, sdpOffer, bbbUserId, role, bbbUserName) {
     return new Promise(async (resolve, reject) => {
       this._status = C.MEDIA_STARTING;
@@ -501,7 +552,7 @@ module.exports = class Screenshare extends BaseProvider {
         try {
           Logger.info(LOG_PREFIX, `Starting presenter screensharing session`,
             this._getFullPresenterLogMetadata(connectionId));
-          const sdpAnswer = await this._startPresenter(sdpOffer, bbbUserId, bbbUserName);
+          const sdpAnswer = await this._startPresenter(sdpOffer, bbbUserId, bbbUserName, connectionId);
           return resolve(sdpAnswer);
         }
         catch (err) {
@@ -511,9 +562,10 @@ module.exports = class Screenshare extends BaseProvider {
     });
   }
 
-  _startPresenter (sdpOffer, userId, bbbUserName) {
+  _startPresenter (sdpOffer, userId, bbbUserName, connectionId) {
     return new Promise(async (resolve, reject) => {
       try {
+        await this.getBroadcastPermission(this._meetingId, this._voiceBridge, userId, connectionId);
         const presenterMCSUserId = await this.mcs.join(
           this._voiceBridge,
           'SFU',
@@ -633,6 +685,7 @@ module.exports = class Screenshare extends BaseProvider {
       this._viewersCandidatesQueue[connectionId] = [];
 
       try {
+        await this.getSubscribePermission(this._meetingId, voiceBridge, userId, presenterEndpoint, connectionId);
         const mcsUserId = await this.mcs.join(
           this._voiceBridge,
           'SFU',

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -103,6 +103,19 @@ module.exports = class Screenshare extends BaseProvider {
     };
   }
 
+  getConnectionIdAndRole (userId) {
+    if (this.presenterMCSUserId === userId) return { connectionId: this._connectionId, role: C.RECV_ROLE };
+
+    for (const connectionId in this._viewerUsers) {
+      if (this._viewerUsers.hasOwnProperty(connectionId)) {
+        const user = this._viewerUsers[connectionId]
+        if (user.hasOwnProperty('userId') && user['userId'] === userId) {
+          return { connectionId, role: C.RECV_ROLE };
+        }
+      }
+    }
+  };
+
   /* ======= ICE HANDLERS ======= */
 
   async onIceCandidate (candidate, role, userId, connectionId) {

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -384,6 +384,54 @@ module.exports = class Video extends BaseProvider {
 
   /* ======= START/CONNECTION METHODS ======= */
 
+  getBroadcastPermission (meetingId, userId, sfuSessionId) {
+    return new Promise((resolve, reject) => {
+      const onResp = (payload) => {
+        const { meetingId, userId, allowed } = payload;
+        if (meetingId === payload.meetingId
+          && payload.userId === userId
+          && payload.allowed) {
+          return resolve();
+        }
+
+        return reject(errors.SFU_UNAUTHORIZED);
+      }
+
+      const msg = Messaging.generateGetCamBroadcastPermissionReqMsg(
+        meetingId,
+        userId,
+        sfuSessionId
+      );
+      this.bbbGW.once(C.GET_CAM_BROADCAST_PERM_RESP_MSG+sfuSessionId, onResp);
+      this.bbbGW.publish(msg, C.TO_AKKA_APPS_CHAN_2x);
+    });
+  }
+
+  getSubscribePermission (meetingId, userId, streamId, sfuSessionId) {
+    return new Promise((resolve, reject) => {
+      const onResp = (payload) => {
+        const { meetingId, userId, allowed } = payload;
+        if (meetingId === payload.meetingId
+          && payload.userId === userId
+          && payload.allowed) {
+          return resolve();
+        }
+
+        return reject(errors.SFU_UNAUTHORIZED);
+      }
+
+      const msg = Messaging.generateGetCamSubscribePermissionReqMsg(
+        meetingId,
+        userId,
+        streamId,
+        sfuSessionId
+      );
+
+      this.bbbGW.once(C.GET_CAM_SUBSCRIBE_PERM_RESP_MSG+sfuSessionId, onResp);
+      this.bbbGW.publish(msg, C.TO_AKKA_APPS_CHAN_2x);
+    });
+  }
+
   start (sdpOffer, mediaSpecs) {
     return new Promise(async (resolve, reject) => {
       if (this.status !== C.MEDIA_STOPPING && this._status !== C.MEDIA_STOPPED) {
@@ -392,6 +440,20 @@ module.exports = class Video extends BaseProvider {
         this.status = C.MEDIA_STARTING;
 
         try {
+          if (this.shared) {
+            await this.getBroadcastPermission(
+              this.meetingId,
+              this.bbbUserId,
+              this.streamName,
+            );
+          } else {
+            await this.getSubscribePermission(
+              this.meetingId,
+              this.bbbUserId,
+              this.id,
+              this.streamName,
+            );
+          }
           const isConnected = await this.mcs.waitForConnection();
 
           if (!isConnected) {

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -58,8 +58,15 @@ module.exports = class Video extends BaseProvider {
     this._stopRecordingEventFired = false;
     this._stopActionQueued = false;
     this.handleMCSCoreDisconnection = this.handleMCSCoreDisconnection.bind(this);
+    this.disconnectUser = this.disconnectUser.bind(this);
     this.mcs.on(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
     this.record = record;
+    this._trackMeetingEvents();
+  }
+
+  _trackMeetingEvents () {
+    this.bbbGW.on(C.DISCONNECT_ALL_USERS_2x+this.meetingId, this.disconnectUser);
+    this.bbbGW.on(C.USER_LEFT_MEETING_2x+this.bbbUserId, this.disconnectUser);
   }
 
   _getLogMetadata () {
@@ -648,6 +655,9 @@ module.exports = class Video extends BaseProvider {
   async stop () {
     return new Promise(async (resolve, reject) => {
       this.mcs.removeListener(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
+      this.bbbGW.removeListener(C.DISCONNECT_ALL_USERS_2x+this.meetingId, this.disconnectUser);
+      this.bbbGW.removeListener(C.USER_LEFT_MEETING_2x+this.bbbUserId, this.disconnectUser);
+
 
       switch (this.status) {
         case C.MEDIA_STOPPED:
@@ -687,7 +697,7 @@ module.exports = class Video extends BaseProvider {
 
         default:
           Logger.info(LOG_PREFIX, `Stopping video session ${this.streamName}`, this._getLogMetadata());
-          if (this.userId == null) {
+          if (this.userId == null && this.status !== C.MEDIA_NEGOTIATION_FAILED) {
             Logger.info(LOG_PREFIX, `Video session ${this.streamName} stop glare`,
               this._getLogMetadata());
             emitter.once(C.MEDIA_USER_JOINED + this.streamName, () => {
@@ -699,5 +709,22 @@ module.exports = class Video extends BaseProvider {
           }
       }
     });
+  }
+
+  async disconnectUser() {
+    try {
+      Logger.info(LOG_PREFIX, 'Disconnect a video session on UserLeft*/DisconnectAll',
+        this._getLogMetadata());
+      await this.stop();
+    } catch (error) {
+      Logger.warn(LOG_PREFIX, 'Failed to disconnect video session on UserLeft*/DisconnectAll',
+        { ...this._getLogMetadata(), error });
+    } finally {
+      this.bbbGW.publish(JSON.stringify({
+        connectionId: this.connectionId,
+        type: C.VIDEO_APP,
+        id : 'close',
+      }), C.FROM_VIDEO);
+    }
   }
 };


### PR DESCRIPTION
### What does this PR do?
  - Implement media permission probes used with akka-apps:
    * GetGlobalAudioPermissionReqMsg, GetCamBroadcastPermissionReqMsg, GetCamSubscribePermissionReqMsg, GetScreenBroadcastPermissionReqMsg, GetScreenSubscribePermissionReqMsg and its responses
  - Improve user left and meeting end cleanup routines
    * Listen only users are now properly ejected on 2.x user exits
    * Video sessions are now properly cleaned up on 2.x meeting ends, user exits
    * Screen sharing sessions are now properly cleaned up on 2.x meeting ends, user exits
