### PR TITLE
v2.4.29

### DIFF
--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -306,14 +306,23 @@ module.exports = class Video extends BaseProvider {
     }), C.FROM_VIDEO);
   }
 
-  sendPlayStop () {
-    const userCamEvent = Messaging.generateUserCamBroadcastStoppedEventMessage2x(
-      this.meetingId,
-      this.bbbUserId,
-      this.id
-    );
+  sendBroadcastCamStop () {
+    // TODO move parameter checking to the messaging interface
+    if (typeof this.meetingId === 'string'
+      && typeof this.bbbUserId === 'string'
+      && typeof this.id === 'string') {
+      const userCamEvent = Messaging.generateUserCamBroadcastStoppedEventMessage2x(
+        this.meetingId,
+        this.bbbUserId,
+        this.id
+      );
 
-    this.bbbGW.publish(JSON.stringify({
+      this.bbbGW.publish(userCamEvent, C.TO_AKKA_APPS_CHAN_2x);
+    }
+  }
+
+  sendPlayStop () {
+      this.bbbGW.publish(JSON.stringify({
       connectionId: this.connectionId,
       type: 'video',
       role: this.role,
@@ -321,7 +330,7 @@ module.exports = class Video extends BaseProvider {
       cameraId: this.id,
     }), C.FROM_VIDEO);
 
-    this.bbbGW.publish(userCamEvent, C.TO_AKKA_APPS_CHAN_2x);
+    this.sendBroadcastCamStop();
   }
 
   /* ======= RECORDING METHODS ======= */
@@ -644,6 +653,10 @@ module.exports = class Video extends BaseProvider {
           Logger.error(LOG_PREFIX, `Unsubscribe failed for user ${this.userId} with stream ${this.streamName}`,
             { ...this._getLogMetadata(), error }); }
       }
+    }
+
+    if (this.shared) {
+      this.sendBroadcastCamStop();
     }
 
     if (this.notFlowingTimeout) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.28",
+  "version": "2.4.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.4.28",
+  "version": "2.4.29",
   "private": true,
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
## Patch release v2.4.29

### CHANGELOG:

-  video: always send a broadcast stop cmd to akka-apps on a graceful stop d028ad8
   * In some specific scenarios streams could be left dangling in akka-apps, but were cleared in HTML5's mongo collections, leaving a webcam sharer in an inconsistent state. This guarantees the stream will be removed from akka-apps whenever there's a graceful shutdown.
   * Comes at the expense of potentially duplicated BroadcastStop messages. They're idempotent, so it isn't a big deal. To properly fix this some of the state logic has to be rewritten in multiple components, so this is what works right now.